### PR TITLE
concours 기능 추가

### DIFF
--- a/src/lib/components/layout/header.svelte
+++ b/src/lib/components/layout/header.svelte
@@ -46,8 +46,11 @@
         },
         { 
             name: 'Application', 
-            href: '/application',
-            subItems: null
+            href: '/application/audition',
+            subItems: [
+                { name: "audition", href: '/application/audition' },
+                { name: "concours", href: '/application/concours' },
+            ]
         },
         {
             name: "Fioreum",

--- a/src/routes/admin/concours/+page.svelte
+++ b/src/routes/admin/concours/+page.svelte
@@ -12,33 +12,31 @@
   // ── 폼 데이터 ──────────────────────────────
   let form = $state({
     title: '',
-    date: '',
-    start_date: '',
-    end_date: '',
-    content: '',
-    apply_link: '',
+    overview: '',
+    description: '',
+    divisions: [],
+    schedule_items: [],
+    repertoire: [],
+    prizes: [],
+    entry_fee: '',
+    rules: [],
     poster_media_id: null,
     banner_image_media_id: null,
-    image_list: [],
     is_active: true,
   });
 
-  // ── 미디어 & 이미지 상태 ─────────────────────
+  // ── 포스터 이미지 상태 ─────────────────────
   let mediaList = $state([]);
   let showMediaPicker = $state(false);
-  let showBannerMediaPicker = $state(false);
-  let showSubMediaPicker = $state(false);
   let selectedPosterUrl = $state('');
-  let selectedBannerUrl = $state('');
-
   let imageDragOver = $state(false);
-  let bannerDragOver = $state(false);
-  let subImageDragOver = $state(false);
-  let subImageUploading = $state(false);
   let pendingPosterFile = $state(null);
+
+  // ── 배너 이미지 상태 ───────────────────────
+  let showBannerMediaPicker = $state(false);
+  let selectedBannerUrl = $state('');
+  let bannerDragOver = $state(false);
   let pendingBannerFile = $state(null);
-  /** 아직 업로드 안 된 서브 이미지 File 객체 목록 (저장 시 업로드) */
-  let pendingSubImageFiles = $state([]);
 
   // ── 초기 로드 ──────────────────────────────
   $effect(() => { loadItems(); });
@@ -46,7 +44,7 @@
   async function loadItems() {
     loading = true;
     try {
-      const res = await fetch(`${API}/api/concours?active_only=false`);
+      const res = await fetch(`${API}/api/concours/?active_only=false`);
       items = await res.json();
     } catch (e) {
       console.error('Failed to load concours:', e);
@@ -67,14 +65,14 @@
   // ── 폼 초기화 ──────────────────────────────
   function resetForm() {
     form = {
-      title: '', date: '', start_date: '', end_date: '', content: '', apply_link: '',
-      poster_media_id: null, banner_image_media_id: null, image_list: [], is_active: true,
+      title: '', overview: '', description: '', divisions: [], schedule_items: [],
+      repertoire: [], prizes: [], entry_fee: '', rules: [],
+      poster_media_id: null, banner_image_media_id: null, is_active: true,
     };
     selectedPosterUrl = '';
-    selectedBannerUrl = '';
     pendingPosterFile = null;
+    selectedBannerUrl = '';
     pendingBannerFile = null;
-    pendingSubImageFiles = [];
     editing = null;
     showForm = false;
   }
@@ -88,22 +86,26 @@
     editing = item;
     form = {
       title: item.title || '',
-      date: item.date || '',
-      start_date: item.start_date || '',
-      end_date: item.end_date || '',
-      content: item.content || '',
-      apply_link: item.apply_link || '',
+      overview: item.overview || '',
+      description: item.description || '',
+      divisions: item.divisions ? [...item.divisions] : [],
+      schedule_items: item.schedule_items ? item.schedule_items.map(s => ({ ...s })) : [],
+      repertoire: item.repertoire ? [...item.repertoire] : [],
+      prizes: item.prizes ? [...item.prizes] : [],
+      entry_fee: item.entry_fee || '',
+      rules: item.rules ? [...item.rules] : [],
       poster_media_id: null,
       banner_image_media_id: null,
       is_active: item.is_active ?? true,
     };
     selectedPosterUrl = item.poster_url || '';
+    pendingPosterFile = null;
     selectedBannerUrl = item.banner_image_url || '';
-    form.image_list = item.image_list ? [...item.image_list] : [];
+    pendingBannerFile = null;
     showForm = true;
   }
 
-  // ── 포스터 ────────────────────────────────
+  // ── 포스터 이미지 ──────────────────────────
   function handleImageDrop(e) {
     e.preventDefault(); imageDragOver = false;
     const file = e.dataTransfer?.files?.[0];
@@ -144,7 +146,7 @@
     showMediaPicker = false;
   }
 
-  // ── 배너 이미지 ──────────────────────────
+  // ── 배너 이미지 ───────────────────────────
   function handleBannerDrop(e) {
     e.preventDefault(); bannerDragOver = false;
     const file = e.dataTransfer?.files?.[0];
@@ -185,57 +187,28 @@
     showBannerMediaPicker = false;
   }
 
-  // ── 서브 이미지 ────────────────────────────
-  async function openSubMediaPicker() {
-    await loadMedia();
-    showSubMediaPicker = true;
+  // ── 동적 리스트 헬퍼 ──────────────────────
+  function addListItem(arr) {
+    return [...arr, ''];
   }
-  function selectSubMedia(media) {
-    if (!form.image_list.find(img => img.media_id === media.id)) {
-      form.image_list = [...form.image_list, { media_id: media.id, url: media.thumb_url || media.url }];
-    }
-    showSubMediaPicker = false;
+  function removeListItem(arr, idx) {
+    return arr.filter((_, i) => i !== idx);
   }
-  function removeSubImage(idx) {
-    const img = form.image_list[idx];
-    if (!img.media_id) {
-      pendingSubImageFiles = pendingSubImageFiles.filter(f => f._previewUrl !== img.url);
-      URL.revokeObjectURL(img.url);
-    }
-    form.image_list = form.image_list.filter((_, i) => i !== idx);
+  function updateListItem(arr, idx, value) {
+    return arr.map((v, i) => i === idx ? value : v);
   }
-  function handleSubImageDrop(e) {
-    e.preventDefault();
-    subImageDragOver = false;
-    const file = e.dataTransfer?.files?.[0];
-    if (file && file.type.startsWith('image/')) addSubImageLocally(file);
+
+  // ── 일정 헬퍼 ─────────────────────────────
+  function addScheduleItem() {
+    form.schedule_items = [...form.schedule_items, { start_date: '', end_date: '', description: '' }];
   }
-  function handleSubImageFileSelect(e) {
-    const file = e.target.files?.[0];
-    if (file) addSubImageLocally(file);
-    e.target.value = '';
+  function removeScheduleItem(idx) {
+    form.schedule_items = form.schedule_items.filter((_, i) => i !== idx);
   }
-  function addSubImageLocally(file) {
-    const previewUrl = URL.createObjectURL(file);
-    file._previewUrl = previewUrl;
-    pendingSubImageFiles = [...pendingSubImageFiles, file];
-    form.image_list = [...form.image_list, { media_id: null, url: previewUrl }];
-  }
-  async function flushPendingSubImages() {
-    if (pendingSubImageFiles.length === 0) return;
-    for (const file of pendingSubImageFiles) {
-      const fd = new FormData();
-      fd.append('file', file);
-      fd.append('category', 'concert');
-      const res = await fetch(`${API}/api/media`, { method: 'POST', body: fd });
-      if (!res.ok) throw new Error(await res.text());
-      const media = await res.json();
-      form.image_list = form.image_list.map(img =>
-        img.url === file._previewUrl ? { media_id: media.id, url: media.url } : img
-      );
-      URL.revokeObjectURL(file._previewUrl);
-    }
-    pendingSubImageFiles = [];
+  function updateScheduleItem(idx, key, value) {
+    form.schedule_items = form.schedule_items.map((s, i) =>
+      i === idx ? { ...s, [key]: value } : s
+    );
   }
 
   // ── 저장 ───────────────────────────────────
@@ -243,22 +216,35 @@
     try {
       await flushPendingPoster();
       await flushPendingBanner();
-      await flushPendingSubImages();
     } catch (e) {
       alert('이미지 업로드 실패: ' + e.message);
       return;
     }
 
+    const cleanSchedule = form.schedule_items.map(s => ({
+      start_date: s.start_date,
+      end_date: s.end_date || undefined,
+      description: s.description,
+    })).filter(s => s.start_date);
+
     const formData = new FormData();
     formData.append('title', form.title);
-    if (form.date) formData.append('date', form.date);
-    if (form.start_date) formData.append('start_date', form.start_date);
-    if (form.end_date) formData.append('end_date', form.end_date);
-    if (form.content) formData.append('content', form.content);
-    formData.append('apply_link', form.apply_link || '');
+    if (form.overview) formData.append('overview', form.overview);
+    if (form.description) formData.append('description', form.description);
+    formData.append('divisions', JSON.stringify(form.divisions.filter(v => v.trim())));
+    formData.append('schedule_items', JSON.stringify(cleanSchedule));
+    formData.append('repertoire', JSON.stringify(form.repertoire.filter(v => v.trim())));
+    formData.append('prizes', JSON.stringify(form.prizes.filter(v => v.trim())));
+    if (form.entry_fee) formData.append('entry_fee', form.entry_fee);
+    formData.append('rules', JSON.stringify(form.rules.filter(v => v.trim())));
     if (form.poster_media_id) formData.append('poster_media_id', String(form.poster_media_id));
+    if (editing && !form.poster_media_id && !pendingPosterFile && !selectedPosterUrl) {
+      formData.append('clear_poster', 'true');
+    }
     if (form.banner_image_media_id) formData.append('banner_image_media_id', String(form.banner_image_media_id));
-    formData.append('image_list', JSON.stringify(form.image_list));
+    if (editing && !form.banner_image_media_id && !pendingBannerFile && !selectedBannerUrl) {
+      formData.append('clear_banner', 'true');
+    }
     formData.append('is_active', String(form.is_active));
 
     try {
@@ -306,9 +292,8 @@
           <tr>
             <th>포스터</th>
             <th>제목</th>
-            <th>시작일</th>
-            <th>마감일</th>
-            <th>지원 링크</th>
+            <th>참가 부분</th>
+            <th>참가비</th>
             <th>상태</th>
             <th>작업</th>
           </tr>
@@ -324,15 +309,14 @@
                 {/if}
               </td>
               <td class="name-cell">{item.title}</td>
-              <td>{item.start_date || '-'}</td>
-              <td>{item.end_date || '-'}</td>
-              <td>
-                {#if item.apply_link}
-                  <a href={item.apply_link} target="_blank" rel="noreferrer" class="link-cell">링크</a>
+              <td class="divisions-cell">
+                {#if item.divisions?.length}
+                  {item.divisions.slice(0, 2).join(', ')}{item.divisions.length > 2 ? ' ...' : ''}
                 {:else}
                   -
                 {/if}
               </td>
+              <td>{item.entry_fee || '-'}</td>
               <td>
                 <span class="badge" class:active={item.is_active}>
                   {item.is_active ? '활성' : '비활성'}
@@ -345,7 +329,7 @@
             </tr>
           {/each}
           {#if items.length === 0}
-            <tr><td colspan="7" class="empty">등록된 콩쿠르가 없습니다.</td></tr>
+            <tr><td colspan="6" class="empty">등록된 콩쿠르가 없습니다.</td></tr>
           {/if}
         </tbody>
       </table>
@@ -355,6 +339,7 @@
   <!-- ── 편집 / 생성 폼 ──────────────────── -->
   {#if showForm}
     <div class="modal-overlay">
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
       <div class="modal" role="none" onclick={(e) => e.stopPropagation()}>
         <button class="modal-close" onclick={resetForm}>✕</button>
         <h2>{editing ? '콩쿠르 편집' : '새 콩쿠르'}</h2>
@@ -366,25 +351,7 @@
             제목 *
             <input type="text" bind:value={form.title} placeholder="콩쿠르 제목" required />
           </label>
-          <label>
-            콩쿨 날짜
-            <input type="date" bind:value={form.date} />
-          </label>
-          <div class="row-2">
-            <label>
-              시작일
-              <input type="date" bind:value={form.start_date} />
-            </label>
-            <label>
-              마감일
-              <input type="date" bind:value={form.end_date} />
-            </label>
-          </div>
-          <label>
-            지원 링크
-            <input type="url" bind:value={form.apply_link} placeholder="https://..." />
-          </label>
-          <label class="checkbox-label">
+          <label class="checkbox-label" style="margin-top: 0.5rem;">
             <input type="checkbox" bind:checked={form.is_active} />
             활성 상태
           </label>
@@ -406,14 +373,14 @@
             {#if selectedPosterUrl}
               <img src={selectedPosterUrl} alt="poster preview" class="preview-img" />
               {#if pendingPosterFile}
-                <p class="drop-hint pending-hint">💾 저장 시 업로드됩니다</p>
+                <p class="drop-hint pending-hint">저장 시 업로드됩니다</p>
               {/if}
             {:else}
               <p class="drop-text">이미지를 드래그하거나 클릭하여 선택</p>
               <p class="drop-hint">저장 버튼을 누를 때 업로드됩니다</p>
             {/if}
           </div>
-          <div style="display:flex; gap:0.5rem; margin-top:0.5rem;">
+          <div class="row-btns">
             <button type="button" class="btn-secondary" onclick={openMediaPicker}>미디어에서 선택</button>
             {#if selectedPosterUrl}
               <button type="button" class="btn-secondary" onclick={() => { selectedPosterUrl = ''; form.poster_media_id = null; pendingPosterFile = null; }}>제거</button>
@@ -423,10 +390,10 @@
 
         <!-- 배너 이미지 -->
         <div class="form-section">
-          <h3>배너 이미지 (Banner Image)</h3>
+          <h3>배너 이미지</h3>
           <!-- svelte-ignore a11y_no_static_element_interactions -->
           <div
-            class="drop-zone banner-drop"
+            class="drop-zone"
             class:drag-over={bannerDragOver}
             class:has-image={!!selectedBannerUrl}
             ondragover={(e) => { e.preventDefault(); bannerDragOver = true; }}
@@ -435,16 +402,16 @@
           >
             <input type="file" accept="image/*" class="file-input" onchange={handleBannerFileSelect} />
             {#if selectedBannerUrl}
-              <img src={selectedBannerUrl} alt="banner preview" class="preview-img banner-preview" />
+              <img src={selectedBannerUrl} alt="banner preview" class="preview-img banner-preview-img" />
               {#if pendingBannerFile}
-                <p class="drop-hint pending-hint">💾 저장 시 업로드됩니다</p>
+                <p class="drop-hint pending-hint">저장 시 업로드됩니다</p>
               {/if}
             {:else}
               <p class="drop-text">이미지를 드래그하거나 클릭하여 선택</p>
               <p class="drop-hint">저장 버튼을 누를 때 업로드됩니다</p>
             {/if}
           </div>
-          <div style="display:flex; gap:0.5rem; margin-top:0.5rem;">
+          <div class="row-btns">
             <button type="button" class="btn-secondary" onclick={openBannerMediaPicker}>미디어에서 선택</button>
             {#if selectedBannerUrl}
               <button type="button" class="btn-secondary" onclick={() => { selectedBannerUrl = ''; form.banner_image_media_id = null; pendingBannerFile = null; }}>제거</button>
@@ -452,47 +419,126 @@
           </div>
         </div>
 
-        <!-- 서브 이미지 목록 -->
+        <!-- 상세 설명 -->
         <div class="form-section">
-          <h3>서브 이미지 목록 (Image List)</h3>
-          <p style="font-size: 0.85rem; color: #666; margin-bottom: 0.75rem;">포스터 외 추가 이미지를 등록할 수 있습니다.</p>
-
-          {#if form.image_list.length > 0}
-            <div class="sub-image-list">
-              {#each form.image_list as img, i}
-                <div class="sub-image-item">
-                  <img src={img.url} alt="서브 이미지 {i + 1}" />
-                  <button class="btn-sm btn-delete remove-sub-btn" onclick={() => removeSubImage(i)}>×</button>
-                </div>
-              {/each}
-            </div>
-          {/if}
-
-          <!-- svelte-ignore a11y_no_static_element_interactions -->
-          <div
-            class="drop-zone sub-drop"
-            class:drag-over={subImageDragOver}
-            ondrop={handleSubImageDrop}
-            ondragover={(e) => { e.preventDefault(); subImageDragOver = true; }}
-            ondragleave={() => subImageDragOver = false}
-          >
-            <input type="file" accept="image/*" class="file-input" onchange={handleSubImageFileSelect} />
-            {#if subImageUploading}
-              <p class="drop-text">업로드 중...</p>
-            {:else}
-              <p class="drop-text">+ 이미지 추가 (드래그 또는 클릭)</p>
-              <p class="drop-hint">저장 버튼을 누를 때 업로드됩니다</p>
-            {/if}
-          </div>
-          <button type="button" class="btn-secondary" style="margin-top:0.5rem" onclick={openSubMediaPicker}>
-            미디어에서 선택
-          </button>
+          <h3>상세 설명</h3>
+          <textarea bind:value={form.description} rows="6" placeholder="콩쿠르 상세 설명을 입력하세요&#10;"></textarea>
         </div>
 
-        <!-- 내용 -->
+        <!-- 모집 개요 -->
         <div class="form-section">
-          <h3>내용</h3>
-          <textarea bind:value={form.content} rows="8" placeholder="콩쿠르 상세 내용을 입력하세요"></textarea>
+          <h3>모집 개요</h3>
+          <textarea bind:value={form.overview} rows="4" placeholder="모집 개요를 입력하세요&#10;"></textarea>
+        </div>
+
+        <!-- 참가 부분 -->
+        <div class="form-section">
+          <h3>참가 부분</h3>
+          <p class="section-hint">예: 학생부 (만 18세 ~ 만 25세), 일반부 (만 40세 ~ 만 59세)</p>
+          {#each form.divisions as div, i}
+            <div class="list-row">
+              <input
+                type="text"
+                value={div}
+                placeholder="참가 부분명 (예: 학생부 만 18~25세)"
+                oninput={(e) => { form.divisions = updateListItem(form.divisions, i, e.target.value); }}
+              />
+              <button type="button" class="btn-remove" onclick={() => { form.divisions = removeListItem(form.divisions, i); }}>×</button>
+            </div>
+          {/each}
+          <button type="button" class="btn-add" onclick={() => { form.divisions = addListItem(form.divisions); }}>+ 부분 추가</button>
+        </div>
+
+        <!-- 일정 안내 -->
+        <div class="form-section">
+          <h3>일정 안내</h3>
+          <p class="section-hint">종료일을 비워두면 단일 날짜로 표시됩니다</p>
+          {#each form.schedule_items as sched, i}
+            <div class="schedule-row">
+              <div class="schedule-dates">
+                <input
+                  type="date"
+                  value={sched.start_date}
+                  oninput={(e) => updateScheduleItem(i, 'start_date', e.target.value)}
+                  placeholder="시작일"
+                />
+                <span class="date-sep">~</span>
+                <input
+                  type="date"
+                  value={sched.end_date || ''}
+                  oninput={(e) => updateScheduleItem(i, 'end_date', e.target.value)}
+                  placeholder="종료일 (선택)"
+                />
+              </div>
+              <div class="schedule-desc-row">
+                <input
+                  type="text"
+                  value={sched.description}
+                  placeholder="내용 (예: 접수기간, 발표 등)"
+                  oninput={(e) => updateScheduleItem(i, 'description', e.target.value)}
+                />
+                <button type="button" class="btn-remove" onclick={() => removeScheduleItem(i)}>×</button>
+              </div>
+            </div>
+          {/each}
+          <button type="button" class="btn-add" onclick={addScheduleItem}>+ 일정 추가</button>
+        </div>
+
+        <!-- 과제곡 -->
+        <div class="form-section">
+          <h3>과제곡</h3>
+          {#each form.repertoire as rep, i}
+            <div class="list-row">
+              <textarea
+                rows="2"
+                value={rep}
+                placeholder="과제곡 (줄바꿈 지원)"
+                oninput={(e) => { form.repertoire = updateListItem(form.repertoire, i, e.target.value); }}
+              ></textarea>
+              <button type="button" class="btn-remove" onclick={() => { form.repertoire = removeListItem(form.repertoire, i); }}>×</button>
+            </div>
+          {/each}
+          <button type="button" class="btn-add" onclick={() => { form.repertoire = addListItem(form.repertoire); }}>+ 과제곡 추가</button>
+        </div>
+
+        <!-- 대회 특전 -->
+        <div class="form-section">
+          <h3>대회 특전</h3>
+          {#each form.prizes as prize, i}
+            <div class="list-row">
+              <textarea
+                rows="2"
+                value={prize}
+                placeholder="특전 내용 (줄바꿈 지원)"
+                oninput={(e) => { form.prizes = updateListItem(form.prizes, i, e.target.value); }}
+              ></textarea>
+              <button type="button" class="btn-remove" onclick={() => { form.prizes = removeListItem(form.prizes, i); }}>×</button>
+            </div>
+          {/each}
+          <button type="button" class="btn-add" onclick={() => { form.prizes = addListItem(form.prizes); }}>+ 특전 추가</button>
+        </div>
+
+        <!-- 참가비 -->
+        <div class="form-section">
+          <h3>참가비</h3>
+          <textarea bind:value={form.entry_fee} rows="3" placeholder="참가비 안내&#10;예: 1인 50,000원&#10;"></textarea>
+        </div>
+
+        <!-- 규정 -->
+        <div class="form-section">
+          <h3>규정</h3>
+          {#each form.rules as rule, i}
+            <div class="list-row">
+              <textarea
+                rows="2"
+                value={rule}
+                placeholder="규정 내용 (줄바꿈 지원)"
+                oninput={(e) => { form.rules = updateListItem(form.rules, i, e.target.value); }}
+              ></textarea>
+              <button type="button" class="btn-remove" onclick={() => { form.rules = removeListItem(form.rules, i); }}>×</button>
+            </div>
+          {/each}
+          <button type="button" class="btn-add" onclick={() => { form.rules = addListItem(form.rules); }}>+ 규정 추가</button>
         </div>
 
         <div class="form-actions">
@@ -508,13 +554,14 @@
   <!-- ── 포스터 미디어 피커 모달 ──────────── -->
   {#if showMediaPicker}
     <div class="modal-overlay">
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
       <div class="modal media-picker" role="none" onclick={(e) => e.stopPropagation()}>
         <button class="modal-close" onclick={() => (showMediaPicker = false)}>✕</button>
         <h2>포스터 이미지 선택</h2>
         <div class="media-grid">
           {#each mediaList as media}
             <button type="button" class="media-item" class:already-selected={form.poster_media_id === media.id} onclick={() => selectMedia(media)}>
-              <img src={media.url} alt={media.original_filename} />
+              <img src={media.thumb_url || media.url} alt={media.original_filename} />
               <span class="media-name">{media.original_filename}</span>
             </button>
           {/each}
@@ -527,44 +574,17 @@
     </div>
   {/if}
 
-  <!-- ── 서브 이미지 미디어 피커 모달 ───────── -->
-  {#if showSubMediaPicker}
-    <div class="modal-overlay">
-      <div class="modal media-picker" role="none" onclick={(e) => e.stopPropagation()}>
-        <button class="modal-close" onclick={() => (showSubMediaPicker = false)}>✕</button>
-        <h2>서브 이미지 선택</h2>
-        <div class="media-grid">
-          {#each mediaList as media}
-            {@const already = form.image_list.some(img => img.media_id === media.id)}
-            <button
-              class="media-item"
-              class:already-selected={already}
-              onclick={() => selectSubMedia(media)}
-              disabled={already}
-            >
-              <img src={media.thumb_url || media.url} alt={media.alt_text || media.original_filename} />
-              <span class="media-name">{already ? '✓ 추가됨' : media.original_filename}</span>
-            </button>
-          {/each}
-          {#if mediaList.length === 0}
-            <p class="empty">업로드된 이미지가 없습니다.</p>
-          {/if}
-        </div>
-        <button class="btn-secondary" onclick={() => (showSubMediaPicker = false)}>닫기</button>
-      </div>
-    </div>
-  {/if}
-
-  <!-- ── 배너 미디어 피커 모달 ─────────────── -->
+  <!-- ── 배너 미디어 피커 모달 ──────────── -->
   {#if showBannerMediaPicker}
     <div class="modal-overlay">
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
       <div class="modal media-picker" role="none" onclick={(e) => e.stopPropagation()}>
         <button class="modal-close" onclick={() => (showBannerMediaPicker = false)}>✕</button>
         <h2>배너 이미지 선택</h2>
         <div class="media-grid">
           {#each mediaList as media}
             <button type="button" class="media-item" class:already-selected={form.banner_image_media_id === media.id} onclick={() => selectBannerMedia(media)}>
-              <img src={media.url} alt={media.original_filename} />
+              <img src={media.thumb_url || media.url} alt={media.original_filename} />
               <span class="media-name">{media.original_filename}</span>
             </button>
           {/each}
@@ -615,7 +635,7 @@
   .thumb { width: 60px; height: 80px; border-radius: 6px; object-fit: cover; }
   .thumb-placeholder { width: 60px; height: 80px; border-radius: 6px; background: #eee; }
   .name-cell { font-weight: 600; color: #111; }
-  .link-cell { color: #2563eb; text-decoration: none; &:hover { text-decoration: underline; } }
+  .divisions-cell { font-size: 0.85rem; color: #555; max-width: 200px; }
 
   .badge {
     padding: 0.2rem 0.6rem; border-radius: 12px; font-size: 0.8rem;
@@ -660,24 +680,72 @@
 
   .form-section {
     margin-bottom: 1.5rem; padding-bottom: 1rem; border-bottom: 1px solid #eee;
-    h3 { margin: 0 0 0.75rem; font-size: 1rem; color: #666; }
+    h3 { margin: 0 0 0.5rem; font-size: 1rem; color: #666; }
     label { display: block; margin-bottom: 0.5rem; font-size: 0.9rem; color: #444; }
-    input[type="text"], input[type="date"], input[type="url"], textarea {
+    input[type="text"], input[type="date"], textarea {
       display: block; width: 100%; margin-top: 0.25rem;
       padding: 0.5rem 0.75rem; background: #fff; border: 1px solid #d1d5db;
       border-radius: 6px; color: #222; font-size: 0.9rem;
+      box-sizing: border-box;
       &:focus { outline: none; border-color: #2563eb; box-shadow: 0 0 0 3px rgba(37,99,235,0.1); }
     }
     textarea { resize: vertical; font-family: inherit; }
   }
 
-  .row-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+  .section-hint {
+    font-size: 0.8rem; color: #aaa; margin: 0 0 0.75rem;
+  }
 
   .checkbox-label {
     display: flex !important; align-items: center; gap: 0.5rem; cursor: pointer;
     input { width: auto; margin: 0; cursor: pointer; }
   }
 
+  .row-btns {
+    display: flex; gap: 0.5rem; margin-top: 0.5rem;
+  }
+
+  /* ── 동적 리스트 ───────────────────── */
+  .list-row {
+    display: flex; align-items: flex-start; gap: 0.5rem; margin-bottom: 0.5rem;
+    input, textarea {
+      flex: 1;
+      margin-top: 0;
+    }
+  }
+
+  .btn-remove {
+    flex-shrink: 0; width: 28px; height: 28px; margin-top: 0.25rem;
+    background: #fee2e2; color: #dc2626; border: none; border-radius: 4px;
+    cursor: pointer; font-size: 1rem; line-height: 1;
+    display: flex; align-items: center; justify-content: center;
+    &:hover { background: #fca5a5; }
+  }
+
+  .btn-add {
+    padding: 0.4rem 0.9rem; background: #f3f4f6; color: #444;
+    border: 1px dashed #9ca3af; border-radius: 6px; cursor: pointer;
+    font-size: 0.85rem; margin-top: 0.25rem;
+    &:hover { background: #e5e7eb; border-color: #6b7280; }
+  }
+
+  /* ── 일정 행 ─────────────────────── */
+  .schedule-row {
+    border: 1px solid #e5e7eb; border-radius: 8px;
+    padding: 0.75rem; margin-bottom: 0.75rem;
+    background: #fafafa;
+  }
+  .schedule-dates {
+    display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.5rem;
+    input[type="date"] { flex: 1; margin-top: 0; }
+  }
+  .date-sep { color: #999; flex-shrink: 0; }
+  .schedule-desc-row {
+    display: flex; align-items: center; gap: 0.5rem;
+    input { flex: 1; margin-top: 0; }
+  }
+
+  /* ── 포스터 드롭존 ───────────────── */
   .drop-zone {
     border: 2px dashed #d1d5db; border-radius: 8px; padding: 2rem;
     text-align: center; cursor: pointer; position: relative;
@@ -692,16 +760,9 @@
       max-width: 200px; max-height: 200px; border-radius: 8px;
       object-fit: contain; display: block; margin: 0 auto;
     }
-  }
-
-  .drop-zone.banner-drop {
-    aspect-ratio: 16 / 5;
-    display: flex; flex-direction: column; align-items: center; justify-content: center;
-    &.has-image { padding: 0.5rem; }
-  }
-  .banner-preview {
-    max-width: 100%; max-height: 180px; border-radius: 6px;
-    object-fit: cover; display: block; margin: 0 auto;
+    .banner-preview-img {
+      max-width: 100%; max-height: 160px;
+    }
   }
 
   .form-actions {
@@ -723,41 +784,5 @@
       display: block; padding: 0.3rem; font-size: 0.7rem; color: #888;
       white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
     }
-  }
-
-  .empty { color: #999; text-align: center; padding: 1rem; }
-
-  /* ── 서브 이미지 목록 ───────────────── */
-  .sub-image-list {
-    display: flex; flex-wrap: wrap; gap: 0.5rem;
-    margin-bottom: 0.75rem;
-  }
-  .sub-image-item {
-    position: relative;
-    width: 90px;
-    height: 90px;
-    border-radius: 6px;
-    overflow: visible;
-    img {
-      width: 100%; height: 100%;
-      object-fit: cover;
-      border-radius: 6px;
-      border: 1px solid #e5e7eb;
-      display: block;
-    }
-    .remove-sub-btn {
-      position: absolute;
-      top: -6px; right: -6px;
-      width: 20px; height: 20px;
-      border-radius: 50%;
-      padding: 0;
-      font-size: 0.85rem;
-      line-height: 1;
-      display: flex; align-items: center; justify-content: center;
-    }
-  }
-  .drop-zone.sub-drop {
-    padding: 1rem;
-    border-style: dashed;
   }
 </style>

--- a/src/routes/application/+layout.svelte
+++ b/src/routes/application/+layout.svelte
@@ -1,0 +1,22 @@
+<script>
+    import { page } from '$app/stores';
+    import { goto } from '$app/navigation';
+    import NavSection from "@/components/common/NavSection.svelte";
+
+    let { children } = $props();
+
+    const filters = ['audition', 'concours'];
+
+    const activeFilter = $derived(
+        $page.url.pathname.includes('/concours') ? 'concours' : 'audition'
+    );
+</script>
+
+<NavSection
+    title="Application"
+    {filters}
+    {activeFilter}
+    onFilter={(f) => goto(`/application/${f}`)}
+/>
+
+{@render children()}

--- a/src/routes/application/+page.server.js
+++ b/src/routes/application/+page.server.js
@@ -1,0 +1,5 @@
+import { redirect } from '@sveltejs/kit';
+
+export function load() {
+    throw redirect(301, '/application/audition');
+}

--- a/src/routes/application/+page.svelte
+++ b/src/routes/application/+page.svelte
@@ -31,7 +31,7 @@
                  .sort((a, b) => (b.start_date ?? '').localeCompare(a.start_date ?? ''))
     );
 
-    const filters = ['auditions',];
+    const filters = ['auditions', 'concourse'];
     let activeFilter = $state('auditions');
 
 </script>

--- a/src/routes/application/audition/+page.svelte
+++ b/src/routes/application/audition/+page.svelte
@@ -1,0 +1,96 @@
+<script>
+    import { PIANOLIFE_BACKEND_URL } from "$env/static/public";
+    import AuditionCard from "@/components/auditions/AuditionCard.svelte";
+
+    const API = PIANOLIFE_BACKEND_URL || "http://localhost:8000";
+
+    let auditions = $state([]);
+    let loading = $state(true);
+    let error = $state(null);
+
+    $effect(() => {
+        fetch(`${API}/api/auditions/?active_only=false`)
+            .then(res => {
+                if (!res.ok) throw new Error(`서버 오류: ${res.status}`);
+                return res.json();
+            })
+            .then(data => { auditions = data; })
+            .catch(err => { error = err.message; })
+            .finally(() => { loading = false; });
+    });
+
+    const today = new Date().toISOString().slice(0, 10);
+
+    const activeAuditions = $derived(
+        auditions.filter(a => a.is_active && (!a.end_date || a.end_date >= today))
+                 .sort((a, b) => (a.start_date ?? '').localeCompare(b.start_date ?? ''))
+    );
+    const closedAuditions = $derived(
+        auditions.filter(a => !a.is_active || (a.end_date && a.end_date < today))
+                 .sort((a, b) => (b.start_date ?? '').localeCompare(a.start_date ?? ''))
+    );
+
+</script>
+
+<svelte:head>
+    <title>Audition - Fiore</title>
+</svelte:head>
+
+<div>
+    <section class="auditions-section">
+        {#if loading}
+            {#each { length: 2 } as _}
+                <div class="card-skeleton"></div>
+            {/each}
+        {:else if error}
+            <p class="empty-message">오류가 발생했습니다: {error}</p>
+        {:else if activeAuditions.length === 0}
+            <p class="empty-message">현재 모집 중인 오디션이 없습니다.</p>
+        {:else}
+            {#each activeAuditions as audition (audition.id)}
+                <AuditionCard {audition} />
+            {/each}
+        {/if}
+    </section>
+</div>
+
+<style lang="scss">
+    section {
+        max-width: 900px;
+        margin: 0 auto;
+    }
+
+    .auditions-section {
+        display: flex;
+        flex-direction: column;
+        padding: 2rem;
+        margin-top: 1rem;
+        padding-bottom: 6rem;
+
+        @media(--mobile) {
+            padding: 0.5rem;
+        }
+    }
+
+    .card-skeleton {
+        height: 250px;
+        border: 0.5px solid #eee;
+        margin-bottom: -0.5px;
+        background: linear-gradient(90deg, #f5f5f5 25%, #ececec 50%, #f5f5f5 75%);
+        background-size: 200% 100%;
+        animation: shimmer 1.4s infinite;
+    }
+
+    @keyframes shimmer {
+        0%   { background-position: 200% 0; }
+        100% { background-position: -200% 0; }
+    }
+
+    .empty-message {
+        color: #aaa;
+        font-size: 0.9rem;
+        font-weight: 300;
+        padding: 3rem 0;
+        text-align: center;
+    }
+</style>

--- a/src/routes/application/concours/+page.svelte
+++ b/src/routes/application/concours/+page.svelte
@@ -1,0 +1,458 @@
+<script>
+    import { PIANOLIFE_BACKEND_URL } from "$env/static/public";
+    import HeroSection from "@/components/common/HeroSection.svelte";
+
+    const API = PIANOLIFE_BACKEND_URL || "http://localhost:8000";
+
+    let concours = $state(null);
+    let loading = $state(true);
+    let error = $state(null);
+
+    $effect(() => {
+        const today = new Date().toISOString().slice(0, 10);
+
+        fetch(`${API}/api/concours/?active_only=true`)
+            .then(res => {
+                if (!res.ok) throw new Error(`서버 오류: ${res.status}`);
+                return res.json();
+            })
+            .then(list => {
+                if (!Array.isArray(list) || list.length === 0) return;
+
+                // 각 콩쿠르의 "가장 빠른 미래 일정" 날짜 계산
+                function getSoonestDate(c) {
+                    const dates = [];
+                    for (const s of (c.schedule_items || [])) {
+                        if (s.end_date && s.end_date >= today) dates.push(s.end_date);
+                        else if (s.start_date && s.start_date >= today) dates.push(s.start_date);
+                    }
+                    return dates.length ? dates.sort()[0] : null;
+                }
+
+                const sorted = [...list].sort((a, b) => {
+                    const da = getSoonestDate(a) ?? '9999-99-99';
+                    const db = getSoonestDate(b) ?? '9999-99-99';
+                    return da.localeCompare(db);
+                });
+
+                concours = sorted[0];
+            })
+            .catch(err => { error = err.message; })
+            .finally(() => { loading = false; });
+    });
+
+    function formatDate(dateStr) {
+        if (!dateStr) return '';
+        const m = dateStr.match(/(\d{4})-(\d{2})-(\d{2})/);
+        if (!m) return dateStr;
+        return `${m[1]}. ${+m[2]}. ${+m[3]}.`;
+    }
+
+    function formatScheduleDate(s) {
+        if (s.end_date) return `${formatDate(s.start_date)} ~ ${formatDate(s.end_date)}`;
+        return formatDate(s.start_date);
+    }
+
+    function inView(node, { threshold = 0.15 } = {}) {
+        const observer = new IntersectionObserver(
+            ([entry]) => {
+                if (entry.isIntersecting) {
+                    node.classList.add('visible');
+                    observer.disconnect();
+                }
+            },
+            { threshold }
+        );
+        observer.observe(node);
+        return { destroy() { observer.disconnect(); } };
+    }
+</script>
+
+<svelte:head>
+    <title>{concours ? concours.title : '콩쿠르'} - Fiore</title>
+</svelte:head>
+
+{#if loading}
+    <div class="state-box">
+        <div class="skeleton-hero"></div>
+        <div class="skeleton-body">
+            <div class="skeleton-block tall"></div>
+            <div class="skeleton-lines">
+                {#each { length: 5 } as _}
+                    <div class="skeleton-line"></div>
+                {/each}
+            </div>
+        </div>
+    </div>
+{:else if error}
+    <div class="state-box centered">
+        <p class="state-msg">{error}</p>
+    </div>
+{:else if !concours}
+    <div class="state-box centered">
+        <p class="state-msg">현재 진행 중인 콩쿠르가 없습니다.</p>
+    </div>
+{:else}
+    <div class="concours-detail-page">
+        <!-- <HeroSection image={concours.poster_url} maxHeight="700px" /> -->
+
+        <section class="main-content-section">
+            <!-- 포스터 (sticky left) -->
+            <div class="main-poster">
+                {#if concours.poster_url}
+                    <img
+                        class="main-poster-image"
+                        src={concours.poster_url}
+                        alt={concours.title}
+                        use:inView
+                    />
+                {:else}
+                    <div class="poster-placeholder"></div>
+                {/if}
+            </div>
+
+            <!-- 기본 정보 -->
+            <div class="information-container">
+                <div>
+                    <h1 class="concours-title">{concours.title}</h1>
+
+                    {#if concours.overview}
+                        <div class="overview-block">
+                            <h3 class="underbar">모집 개요</h3>
+                            <p class="text-pre">{concours.overview}</p>
+                        </div>
+                    {/if}
+
+                    {#if concours.description}
+                        <div class="overview-block">
+                            <h3 class="underbar">상세 설명</h3>
+                            <p class="text-pre">{concours.description}</p>
+                        </div>
+                    {/if}
+
+                    {#if concours.entry_fee}
+                        <div class="fee-block">
+                            <h3 class="underbar">참가비</h3>
+                            <p class="text-pre">{concours.entry_fee}</p>
+                        </div>
+                    {/if}
+                </div>
+            </div>
+
+            <!-- 상세 섹션 -->
+            <div class="content-container">
+
+                <!-- 참가 부분 -->
+                {#if concours.divisions?.length}
+                    <div class="detail-section">
+                        <h3 class="underbar">참가 부분</h3>
+                        <ul>
+                            {#each concours.divisions as div}
+                                <li>{div}</li>
+                            {/each}
+                        </ul>
+                    </div>
+                {/if}
+
+                <!-- 일정 안내 -->
+                {#if concours.schedule_items?.length}
+                    <div class="detail-section">
+                        <h3 class="underbar">일정 안내</h3>
+                        <div class="schedule-table">
+                            {#each concours.schedule_items as s}
+                                <div class="schedule-row">
+                                    <span class="schedule-desc">{s.description}</span>
+                                    <span class="schedule-date">{formatScheduleDate(s)}</span>
+                                </div>
+                            {/each}
+                        </div>
+                    </div>
+                {/if}
+
+                <!-- 과제곡 -->
+                {#if concours.repertoire?.length}
+                    <div class="detail-section">
+                        <h3 class="underbar">과제곡</h3>
+                        <ul>
+                            {#each concours.repertoire as rep, i}
+                                <li>
+                                    <span>{rep}</span>
+                                </li>
+                            {/each}
+                        </ul>
+                    </div>
+                {/if}
+
+                <!-- 대회 특전 -->
+                {#if concours.prizes?.length}
+                    <div class="detail-section">
+                        <h3 class="underbar">대회 특전</h3>
+                        <ul class="bullet-list">
+                            {#each concours.prizes as prize}
+                                <li>{prize}</li>
+                            {/each}
+                        </ul>
+                    </div>
+                {/if}
+
+                <!-- 규정 -->
+                {#if concours.rules?.length}
+                    <div class="detail-section">
+                        <h3 class="underbar">규정</h3>
+                        <ul class="bullet-list">
+                            {#each concours.rules as rule}
+                                <li>{rule}</li>
+                            {/each}
+                        </ul>
+                    </div>
+                {/if}
+
+            </div>
+        </section>
+    </div>
+{/if}
+
+<style lang="scss">
+    /* ── 로딩 / 에러 상태 ──────────────────── */
+    .state-box {
+        width: 100%;
+        &.centered {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 60vh;
+        }
+    }
+    .state-msg {
+        color: #999;
+        font-weight: 300;
+        font-size: 0.95rem;
+    }
+    .skeleton-hero {
+        width: 100%;
+        aspect-ratio: 16/9;
+        max-height: 700px;
+        background: #e8e8e8;
+        animation: shimmer 1.4s infinite;
+        background: linear-gradient(90deg, #f0f0f0 25%, #e4e4e4 50%, #f0f0f0 75%);
+        background-size: 200% 100%;
+    }
+    .skeleton-body {
+        display: grid;
+        grid-template-columns: 300px 1fr;
+        gap: 2rem;
+        padding: 2rem;
+        max-width: 1400px;
+        margin: 0 auto;
+    }
+    .skeleton-block {
+        background: linear-gradient(90deg, #f0f0f0 25%, #e4e4e4 50%, #f0f0f0 75%);
+        background-size: 200% 100%;
+        animation: shimmer 1.4s infinite;
+        border-radius: 4px;
+        &.tall { aspect-ratio: 3/4; }
+    }
+    .skeleton-lines { display: flex; flex-direction: column; gap: 0.75rem; padding-top: 1rem; }
+    .skeleton-line {
+        height: 1rem; border-radius: 4px;
+        background: linear-gradient(90deg, #f0f0f0 25%, #e4e4e4 50%, #f0f0f0 75%);
+        background-size: 200% 100%;
+        animation: shimmer 1.4s infinite;
+        &:nth-child(odd) { width: 80%; }
+    }
+    @keyframes shimmer {
+        0%   { background-position: 200% 0; }
+        100% { background-position: -200% 0; }
+    }
+
+    /* ── 페이지 ──────────────────────────── */
+    .concours-detail-page {
+        width: 100%;
+    }
+
+    .main-content-section {
+        display: grid;
+        grid-template-columns: 400px 1fr;
+        gap: 2rem;
+        max-width: 1400px;
+        margin: 0 auto;
+        padding: 2rem;
+
+        @media(--desktop) {
+            grid-template-columns: 1fr;
+        }
+        @media(--tablet) {
+            gap: 1.5rem;
+        }
+        @media(--mobile) {
+            gap: 1rem;
+            padding: 1rem;
+        }
+    }
+
+    /* ── 포스터 ──────────────────────────── */
+    .main-poster {
+        position: sticky;
+        top: 80px;
+        align-self: start;
+        grid-row: 1 / -1;
+            margin: 0 auto;
+
+
+        @media(--desktop) {
+            position: static;
+            grid-row: 1 / 2;
+        }
+
+        .main-poster-image {
+            width: 100%;
+            max-width: 800px;
+            height: auto;
+            opacity: 0;
+            transform: translateY(16px);
+            transition: opacity 0.6s ease, transform 0.6s ease;
+
+            &:global(.visible) {
+                opacity: 1;
+                transform: translateY(0);
+            }
+        }
+
+        .poster-placeholder {
+            width: 100%;
+            aspect-ratio: 3/4;
+            background: linear-gradient(135deg, #e8e4f0, #d8d0e8);
+        }
+    }
+
+    /* ── 기본 정보 ───────────────────────── */
+    .information-container {
+        display: flex;
+        flex-direction: column;
+        justify-content: flex-start;
+        padding-top: 0.5rem;
+    }
+
+    .concours-title {
+        font-size: 1.8rem;
+        font-weight: 300;
+        color: #111;
+        margin: 0 0 1.5rem;
+        line-height: 1.3;
+        letter-spacing: 0.01em;
+
+        @media(--tablet) { font-size: 1.4rem; }
+        @media(--mobile) { font-size: 1.1rem; margin-bottom: 1rem; }
+    }
+
+    .overview-block,
+    .fee-block {
+        margin-bottom: 1.5rem;
+    }
+
+    h3 {
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: #555;
+        margin: 0;
+        margin-top : 3rem;
+    }
+    .underbar {
+        padding-bottom: 0.5rem;
+        border-bottom: 0.5px solid #eee;
+        margin-bottom: 1rem;
+    }
+
+    .text-pre {
+        font-size: 0.9rem;
+        margin: 0;
+        white-space: pre-line;
+        padding-left: 1rem;
+    }
+
+    /* ── 상세 섹션 컨테이너 ─────────────── */
+    .content-container {
+        display: flex;
+        flex-direction: column;
+        gap: 3rem;
+        width: 100%;
+        min-width: 0;
+        padding: 0.5rem 0 4rem;
+        grid-column: 2 / -1;
+
+        @media(--desktop) {
+            grid-column: 1 / -1;
+        }
+    }
+
+    .detail-section {
+        width: 100%;
+    }
+
+    ul {
+        list-style: square;
+        padding: 0;
+        margin: 0;
+        display: flex;
+        flex-direction: column;
+        padding-left: 1rem;
+
+        li {
+            padding: 0.5rem 0 0.5rem 1rem;
+            font-size: 0.88rem;
+            font-weight: 300;
+        }
+    }
+
+    /* ── 일정 표 ─────────────────────────── */
+    .schedule-table {
+        display: flex;
+        flex-direction: column;
+        gap: 0;
+    }
+    .schedule-row {
+        display: grid;
+        grid-template-columns: 220px 1fr;
+        gap: 1.5rem;
+        padding: 0.5rem 0 0.5rem 1rem;
+        border-bottom: 0.5px solid #f0f0f0;
+        align-items: baseline;
+
+        @media(--mobile) {
+            grid-template-columns: 1fr;
+            gap: 0.25rem;
+        }
+    }
+    .schedule-date {
+        font-size: 0.88rem;
+        font-weight: 400;
+        color: #888;
+        font-variant-numeric: tabular-nums;
+        white-space: nowrap;
+    }
+    .schedule-desc {
+        font-size: 0.9rem;
+        font-weight: 300;
+        color: #333;
+    }
+
+    /* ── 불릿 목록 (특전/규정) ───────────── */
+    .bullet-list {
+        list-style: square;
+        padding: 0;
+        padding-left: 1rem;
+        margin: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 0;
+
+        li {
+            padding: 0.75rem 0 0.75rem 1rem;
+            border-bottom: 0.5px solid #f0f0f0;
+            position: relative;
+            font-size: 0.9rem;
+            font-weight: 300;
+            color: #444;
+        }
+    }
+</style>

--- a/src/routes/home/HomePage.svelte
+++ b/src/routes/home/HomePage.svelte
@@ -41,19 +41,15 @@
     onMount(async () => {
         const today = new Date().toISOString().slice(0, 10); // "YYYY-MM-DD"
 
-        // const [concertsRes, auditionsRes, concoursRes] = await Promise.allSettled([
-        //     fetch(`${API}/api/concerts?active_only=true`).then(r => r.json()),
-        //     fetch(`${API}/api/auditions?active_only=false`).then(r => r.json()),
-        //     fetch(`${API}/api/concours?active_only=false`).then(r => r.json()),
-        // ]);
-        const [concertsRes, auditionsRes] = await Promise.allSettled([
+        const [concertsRes, auditionsRes, concoursRes] = await Promise.allSettled([
             fetch(`${API}/api/concerts?active_only=true`).then(r => r.json()),
-            fetch(`${API}/api/auditions?active_only=false`).then(r => r.json())
+            fetch(`${API}/api/auditions?active_only=true`).then(r => r.json()),
+            fetch(`${API}/api/concours/?active_only=true`).then(r => r.json()),
         ]);
-        
+
         const newSlides = [{ type: 'main' }];
 
-        // 가장 가까운 예정 공연 (date >= today)
+        // 가장 가까운 예정 공연 1개 (date >= today)
         if (concertsRes.status === 'fulfilled' && Array.isArray(concertsRes.value)) {
             const upcoming = concertsRes.value
                 .filter(c => c.date && c.date >= today)
@@ -63,14 +59,9 @@
                 const image = c.banner_image_url || c.poster_url;
                 if (image) newSlides.push({ type: 'link', image, link: `/concerts/${c.id}` });
             }
-            if(upcoming.length > 1) {
-                const c = upcoming[1];
-                const image = c.banner_image_url || c.poster_url;
-                if (image) newSlides.push({ type: 'link', image, link: `/concerts/${c.id}` });
-            }
         }
 
-        // 가장 가까운 오디션 (end_date >= today)
+        // 가장 가까운 오디션 1개 (end_date >= today)
         if (auditionsRes.status === 'fulfilled' && Array.isArray(auditionsRes.value)) {
             const upcoming = auditionsRes.value
                 .filter(a => a.end_date && a.end_date >= today)
@@ -78,21 +69,18 @@
             if (upcoming.length > 0) {
                 const a = upcoming[0];
                 const image = a.banner_image_url || a.poster_url;
-                if (image) newSlides.push({ type: 'link', image, link: `/auditions/${a.id}` });
+                if (image) newSlides.push({ type: 'link', image, link: `/application/auditions/${a.id}` });
             }
         }
 
-        // 가장 가까운 콩쿠르 (end_date >= today)
-        // if (concoursRes.status === 'fulfilled' && Array.isArray(concoursRes.value)) {
-        //     const upcoming = concoursRes.value
-        //         .filter(c => c.end_date && c.end_date >= today)
-        //         .sort((a, b) => a.end_date.localeCompare(b.end_date));
-        //     if (upcoming.length > 0) {
-        //         const c = upcoming[0];
-        //         const image = c.banner_image_url || c.poster_url;
-        //         if (image) newSlides.push({ type: 'link', image, link: `/concours/${c.id}` });
-        //     }
-        // }
+        // 활성화된 콩쿠르 1개 (가장 최근 등록)
+        if (concoursRes.status === 'fulfilled' && Array.isArray(concoursRes.value)) {
+            if (concoursRes.value.length > 0) {
+                const c = concoursRes.value[0];
+                const image = c.poster_url;
+                if (image) newSlides.push({ type: 'link', image, link: `/application/concours` });
+            }
+        }
 
         slides = newSlides;
         // Clamp active index in case placeholders were removed


### PR DESCRIPTION
This pull request refactors the application section to introduce dedicated routes and navigation for "audition" and "concours" (competition) applications, improves the main navigation, and updates the home page to showcase the most relevant audition and concours information. The changes enhance user experience by making navigation clearer and surfacing the most important content.

**Navigation and Routing Improvements:**

* The "Application" menu in the header now links to `/application/audition` and includes sub-navigation for "audition" and "concours" sections.
* Added a new layout for the `/application` route that provides a filterable navigation bar between "audition" and "concours" sections.
* The base `/application` route now automatically redirects to `/application/audition` for a more intuitive entry point.

**Audition Section Enhancements:**

* Added a new page at `/application/audition` that fetches and displays a list of auditions, including loading and error states, and separates active and closed auditions.

**Home Page Content Updates:**

* The home page now fetches and displays the most relevant upcoming audition and concours, showing only the top item for each and linking to the new application subroutes. [[1]](diffhunk://#diff-c5b549a069f2134bf28b028620b6f07b113cd238e437b86513e3fe27a1c2b4e8L44-R52) [[2]](diffhunk://#diff-c5b549a069f2134bf28b028620b6f07b113cd238e437b86513e3fe27a1c2b4e8L66-R83)

**Other Adjustments:**

* Updated the filters in the old audition page to include both "auditions" and "concourse" (likely a typo for "concours").