### PR TITLE
콘서트 등록 시간 선택 문제 수정

### DIFF
--- a/src/routes/admin/concerts/+page.svelte
+++ b/src/routes/admin/concerts/+page.svelte
@@ -1234,6 +1234,20 @@
       &:focus { outline: none; border-color: #2563eb; box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1); }
     }
     textarea { resize: vertical; font-family: inherit; }
+
+    /* Safari: globals.scss의 * { padding: 0 } 리셋이 WebKit 내부 가상 요소에도 적용되어
+       시간/날짜 입력 필드의 클릭 영역이 사라지는 버그 수정 */
+    input[type="date"],
+    input[type="time"] {
+      &::-webkit-datetime-edit-fields-wrapper { padding: 0 2px; }
+      &::-webkit-datetime-edit { padding: 0; display: inline-flex; align-items: center; }
+      &::-webkit-datetime-edit-hour-field,
+      &::-webkit-datetime-edit-minute-field,
+      &::-webkit-datetime-edit-ampm-field,
+      &::-webkit-datetime-edit-month-field,
+      &::-webkit-datetime-edit-day-field,
+      &::-webkit-datetime-edit-year-field { padding: 1px 3px; }
+    }
   }
 
   .row-2 {


### PR DESCRIPTION
This pull request addresses a UI bug affecting date and time input fields in Safari browsers. The main change is a CSS fix to restore the clickable area for these fields, which was lost due to a global style reset.

Bug fix for Safari input fields:

* Updated CSS in `src/routes/admin/concerts/+page.svelte` to add specific padding to WebKit date and time input pseudo-elements, ensuring the clickable area is preserved after the global padding reset.