### PR TITLE
artist 사진, 동영상 깨지던 문제 수정

### DIFF
--- a/src/lib/components/artists2/ArtistDetail2.svelte
+++ b/src/lib/components/artists2/ArtistDetail2.svelte
@@ -29,6 +29,11 @@
         });
     });
 
+    const hideBrokenImage = (e) => {
+        e.currentTarget.closest('.photo-slide, .album-slide, .concert-poster, .hero-media')?.classList.add('img-broken');
+        e.currentTarget.style.display = 'none';
+    };
+
     const videos = $derived(artist.videos || []);
     const links = $derived(artist.links || []);
     const isGroupArtist = $derived(artist.role_name === 'group');
@@ -258,6 +263,7 @@
             <img
                 src={artist.mid_url || artist.image_url}
                 alt={artist.name}
+                onerror={hideBrokenImage}
                 style="object-position: center {focusY}%;"
             />
         </div>
@@ -394,7 +400,7 @@
                             {#each subImages as img}
                                 <div class="photo-slide">
                                     <div class="photo-wrap">
-                                        <img src={img.url} alt="{artist.name} 사진" />
+                                        <img src={img.url} alt="{artist.name} 사진" onerror={hideBrokenImage} />
                                     </div>
                                 </div>
                             {/each}
@@ -472,7 +478,7 @@
                                     aria-current={offset === 0}
                                 >
                                     {#if album.cover_thumb_url || album.cover_url}
-                                        <img src={album.cover_mid_url || album.cover_url} alt={album.title} />
+                                        <img src={album.cover_mid_url || album.cover_url} alt={album.title} onerror={hideBrokenImage} />
                                     {:else}
                                         <div class="album-cover-placeholder"></div>
                                     {/if}
@@ -616,7 +622,7 @@
                         <a href="/concerts/{c.id}" class="concert-card">
                             <div class="concert-poster">
                                 {#if c.poster_url}
-                                    <img src={c.poster_url} alt={c.title} />
+                                    <img src={c.poster_url} alt={c.title} onerror={hideBrokenImage} />
                                 {:else}
                                     <div class="concert-poster-placeholder"></div>
                                 {/if}
@@ -683,6 +689,10 @@
             flex-direction: column;
             min-height: auto;
         }
+    }
+
+    .img-broken {
+        background: linear-gradient(135deg, #1a1a1a, #333);
     }
 
     .hero-media {

--- a/src/routes/admin/artists/+page.svelte
+++ b/src/routes/admin/artists/+page.svelte
@@ -679,7 +679,7 @@
           <h3>동영상 (Video)</h3>
           {#each form.videos as video, i}
             <div class="video-row">
-              <input type="text" bind:value={video.id} placeholder="YouTube ID" />
+              <input type="text" bind:value={video.id} placeholder="YouTube ID 또는 영상 URL" />
               <input type="text" bind:value={video.description} placeholder="설명" />
               <button class="btn-sm btn-delete" onclick={() => removeVideo(i)}>×</button>
             </div>


### PR DESCRIPTION
This pull request improves the user experience on the `ArtistDetail2.svelte` component by handling broken image links more gracefully. It introduces a utility to hide images that fail to load and visually marks their containers, preventing broken image icons from appearing throughout the UI. Additionally, it clarifies the placeholder text in the admin artist video form.

**Image loading improvements:**

* Added a `hideBrokenImage` handler to hide images that fail to load and apply an `.img-broken` class to their container elements, enhancing the visual experience when images are missing. (`src/lib/components/artists2/ArtistDetail2.svelte`)
* Applied the `onerror={hideBrokenImage}` handler to all major image tags, including artist photos, sub-images, album covers, and concert posters, ensuring consistent broken image handling across the component. (`src/lib/components/artists2/ArtistDetail2.svelte`) [[1]](diffhunk://#diff-0fe3e653214f80a108f0e553fa2396f62ce012342934c033db700ec63e311b09R266) [[2]](diffhunk://#diff-0fe3e653214f80a108f0e553fa2396f62ce012342934c033db700ec63e311b09L397-R403) [[3]](diffhunk://#diff-0fe3e653214f80a108f0e553fa2396f62ce012342934c033db700ec63e311b09L475-R481) [[4]](diffhunk://#diff-0fe3e653214f80a108f0e553fa2396f62ce012342934c033db700ec63e311b09L619-R625)
* Introduced the `.img-broken` CSS class with a fallback gradient background for containers of failed images. (`src/lib/components/artists2/ArtistDetail2.svelte`)

**Admin form enhancement:**

* Updated the placeholder text for video ID input to clarify that it accepts either a YouTube ID or a video URL. (`src/routes/admin/artists/+page.svelte`)