### PR TITLE
artist 페이지 빠르게 로드되도록 수정

### DIFF
--- a/src/routes/artists/+page.svelte
+++ b/src/routes/artists/+page.svelte
@@ -5,23 +5,36 @@
     import NavSection from "@/components/common/NavSection.svelte";
 
     const API = PIANOLIFE_BACKEND_URL || "http://localhost:8000";
+    const PAGE_SIZE = 12;
+    const allowedRoles = new Set(["artist", "group"]);
 
     let artists = $state([]);
     let loading = $state(true);
     let error = $state(null);
 
+    async function loadArtists() {
+        let offset = 0;
+        let first = true;
+        while (true) {
+            const res = await fetch(`${API}/api/artists/summary?active_only=true&limit=${PAGE_SIZE}&offset=${offset}`);
+            if (!res.ok) throw new Error(`서버 오류: ${res.status}`);
+            const page = await res.json();
+            if (first) {
+                loading = false;
+                first = false;
+            }
+            if (!page || page.length === 0) break;
+            artists = [...artists, ...page.filter(item => allowedRoles.has(item.role_name))];
+            if (page.length < PAGE_SIZE) break;
+            offset += PAGE_SIZE;
+        }
+    }
+
     $effect(() => {
-        fetch(`${API}/api/artists?active_only=true`)
-            .then(res => {
-                if (!res.ok) throw new Error(`서버 오류: ${res.status}`);
-                return res.json();
-            })
-            .then(data => {
-                const allowedRoles = new Set(["artist", "group"]);
-                artists = (data || []).filter(item => allowedRoles.has(item.role_name));
-            })
-            .catch(err => { error = err.message; })
-            .finally(() => { loading = false; });
+        loadArtists().catch(err => {
+            error = err.message;
+            loading = false;
+        });
     });
 </script>
 


### PR DESCRIPTION
This pull request improves the user experience on the `ArtistDetail2.svelte` component by handling broken image links more gracefully. It introduces a utility to hide images that fail to load and visually marks their containers, preventing broken image icons from appearing throughout the UI. Additionally, it clarifies the placeholder text in the admin artist video form.

**Image loading improvements:**

* Added a `hideBrokenImage` handler to hide images that fail to load and apply an `.img-broken` class to their container elements, enhancing the visual experience when images are missing. (`src/lib/components/artists2/ArtistDetail2.svelte`)
* Applied the `onerror={hideBrokenImage}` handler to all major image tags, including artist photos, sub-images, album covers, and concert posters, ensuring consistent broken image handling across the component. (`src/lib/components/artists2/ArtistDetail2.svelte`) [[1]](diffhunk://#diff-0fe3e653214f80a108f0e553fa2396f62ce012342934c033db700ec63e311b09R266) [[2]](diffhunk://#diff-0fe3e653214f80a108f0e553fa2396f62ce012342934c033db700ec63e311b09L397-R403) [[3]](diffhunk://#diff-0fe3e653214f80a108f0e553fa2396f62ce012342934c033db700ec63e311b09L475-R481) [[4]](diffhunk://#diff-0fe3e653214f80a108f0e553fa2396f62ce012342934c033db700ec63e311b09L619-R625)
* Introduced the `.img-broken` CSS class with a fallback gradient background for containers of failed images. (`src/lib/components/artists2/ArtistDetail2.svelte`)

**Admin form enhancement:**

* Updated the placeholder text for video ID input to clarify that it accepts either a YouTube ID or a video URL. (`src/routes/admin/artists/+page.svelte`)