### PR TITLE
이미지 업로드 관련 ux 최적화'

### DIFF
--- a/src/lib/utils/uploadMedia.js
+++ b/src/lib/utils/uploadMedia.js
@@ -1,0 +1,32 @@
+/**
+ * 탭 백그라운드/일시적 네트워크 오류로 업로드 fetch가 끊겨도
+ * 자동 재시도해서 저장이 계속 진행되도록 하는 헬퍼.
+ */
+export async function fetchWithRetry(url, options = {}, retries = 2, backoffMs = 800) {
+  let lastErr;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const res = await fetch(url, options);
+      if (!res.ok) throw new Error(await res.text());
+      return res;
+    } catch (e) {
+      lastErr = e;
+      if (attempt < retries) {
+        await new Promise((r) => setTimeout(r, backoffMs * (attempt + 1)));
+      }
+    }
+  }
+  throw lastErr;
+}
+
+/** 미디어 파일 업로드 (실패 시 자동 재시도) → 업로드된 media 객체 반환 */
+export async function uploadMediaFile(API, file, category, extra = {}) {
+  const fd = new FormData();
+  fd.append('file', file);
+  fd.append('category', category);
+  for (const [key, value] of Object.entries(extra)) {
+    if (value !== null && value !== undefined) fd.append(key, value);
+  }
+  const res = await fetchWithRetry(`${API}/api/media`, { method: 'POST', body: fd });
+  return res.json();
+}

--- a/src/routes/admin/albums/+page.svelte
+++ b/src/routes/admin/albums/+page.svelte
@@ -1,5 +1,6 @@
 <script>
   import { PIANOLIFE_BACKEND_URL } from '$env/static/public';
+  import { uploadMediaFile, fetchWithRetry } from '$lib/utils/uploadMedia.js';
 
   const API = PIANOLIFE_BACKEND_URL || 'http://localhost:8000';
 
@@ -29,6 +30,8 @@
   let mediaList = $state([]);
   let showMediaPicker = $state(false);
   let selectedCoverUrl = $state('');
+  let saving = $state(false);
+  let saveError = $state('');
 
   // ── 드래그 앤 드롭 ────────────────────────────
   let coverDragOver = $state(false);
@@ -63,7 +66,7 @@
 
   async function loadMedia() {
     try {
-      const res = await fetch(`${API}/api/media?category=album&limit=100`);
+      const res = await fetch(`${API}/api/media?limit=200`);
       const data = await res.json();
       mediaList = data.items || [];
     } catch (e) {
@@ -81,6 +84,8 @@
     pendingCoverFile = null;
     editing = null;
     showForm = false;
+    saving = false;
+    saveError = '';
   }
 
   function openCreate() {
@@ -165,12 +170,7 @@
   /** 저장 시 호출: pending 커버 이미지를 실제 업로드 */
   async function flushPendingCover() {
     if (!pendingCoverFile) return;
-    const fd = new FormData();
-    fd.append('file', pendingCoverFile);
-    fd.append('category', 'album');
-    const res = await fetch(`${API}/api/media`, { method: 'POST', body: fd });
-    if (!res.ok) throw new Error(await res.text());
-    const media = await res.json();
+    const media = await uploadMediaFile(API, pendingCoverFile, 'album');
     form.cover_media_id = media.id;
     selectedCoverUrl = media.thumb_url || media.url;
     URL.revokeObjectURL(pendingCoverFile._previewUrl);
@@ -192,10 +192,15 @@
 
   // ── 저장 ───────────────────────────────────
   async function saveAlbum() {
+    if (saving) return;
+    saving = true;
+    saveError = '';
+
     try {
       await flushPendingCover();
     } catch (e) {
-      alert('이미지 업로드 실패: ' + e.message);
+      saving = false;
+      saveError = '이미지 업로드 실패: ' + (e?.message || e);
       return;
     }
 
@@ -217,13 +222,13 @@
         : `${API}/api/albums`;
       const method = editing ? 'PUT' : 'POST';
 
-      const res = await fetch(url, { method, body: formData });
-      if (!res.ok) throw new Error(await res.text());
+      await fetchWithRetry(url, { method, body: formData });
 
       resetForm();
       await loadAlbums();
     } catch (e) {
-      alert('저장 실패: ' + e.message);
+      saving = false;
+      saveError = '저장 실패: ' + (e?.message || e);
     }
   }
 
@@ -330,12 +335,16 @@
         <div class="modal-header-row">
           <h2>{editing ? '앨범 편집' : '새 앨범'}</h2>
           <div class="modal-header-actions">
-            <button class="btn-primary btn-save-top" onclick={saveAlbum} disabled={!form.title}>
-              {editing ? '수정' : '등록'}
+            <button class="btn-primary btn-save-top" onclick={saveAlbum} disabled={!form.title || saving}>
+              {saving ? '저장 중...' : (editing ? '수정' : '등록')}
             </button>
             <button class="modal-close" onclick={resetForm}>✕</button>
           </div>
         </div>
+
+        {#if saveError}
+          <p class="save-error">{saveError}</p>
+        {/if}
 
         <!-- 기본 정보 -->
         <div class="form-section">
@@ -458,8 +467,8 @@
         </div>
 
         <div class="form-actions">
-          <button class="btn-primary" onclick={saveAlbum} disabled={!form.title}>
-            {editing ? '수정' : '생성'}
+          <button class="btn-primary" onclick={saveAlbum} disabled={!form.title || saving}>
+            {saving ? '저장 중...' : (editing ? '수정' : '생성')}
           </button>
           <button class="btn-secondary" onclick={resetForm}>취소</button>
         </div>
@@ -481,7 +490,7 @@
             </button>
           {/each}
           {#if mediaList.length === 0}
-            <p class="empty">업로드된 앨범 이미지가 없습니다.</p>
+            <p class="empty">업로드된 이미지가 없습니다.</p>
           {/if}
         </div>
         <button class="btn-secondary" onclick={() => (showMediaPicker = false)}>닫기</button>
@@ -626,6 +635,17 @@
     .modal-close { position: static; }
   }
   .btn-save-top { flex-shrink: 0; padding: 0.45rem 1rem; font-size: 0.85rem; }
+
+  .save-error {
+    background: #fef2f2;
+    color: #b91c1c;
+    border: 1px solid #fecaca;
+    border-radius: 6px;
+    padding: 0.6rem 0.9rem;
+    margin: 0 0 1rem;
+    font-size: 0.85rem;
+    white-space: pre-wrap;
+  }
 
   .modal-close {
     position: absolute;

--- a/src/routes/admin/artists/+page.svelte
+++ b/src/routes/admin/artists/+page.svelte
@@ -1,6 +1,7 @@
 <script>
   import { PIANOLIFE_BACKEND_URL } from '$env/static/public';
   import FocusPointModal from '$lib/components/artists/FocusPointModal.svelte';
+  import { uploadMediaFile, fetchWithRetry } from '$lib/utils/uploadMedia.js';
 
   const API = PIANOLIFE_BACKEND_URL || 'http://localhost:8000';
 
@@ -40,6 +41,8 @@
   let mediaList = $state([]);
   let showMediaPicker = $state(false);
   let selectedImageUrl = $state('');
+  let saving = $state(false);
+  let saveError = $state('');
   let imageUploading = $state(false);
   let imageDragOver = $state(false);
   let subImageUploading = $state(false);
@@ -134,6 +137,8 @@
     pendingSubImageFiles = [];
     editing = null;
     showForm = false;
+    saving = false;
+    saveError = '';
   }
 
   function openCreate() {
@@ -244,12 +249,7 @@
   async function flushPendingSubImages() {
     if (pendingSubImageFiles.length === 0) return;
     for (const file of pendingSubImageFiles) {
-      const fd = new FormData();
-      fd.append('file', file);
-      fd.append('category', 'artist');
-      const res = await fetch(`${API}/api/media`, { method: 'POST', body: fd });
-      if (!res.ok) throw new Error(await res.text());
-      const media = await res.json();
+      const media = await uploadMediaFile(API, file, 'artist');
       form.image_list = form.image_list.map(img =>
         img.url === file._previewUrl ? { media_id: media.id, url: media.url } : img
       );
@@ -348,12 +348,7 @@
   /** 저장 시 호출: pending 프로필 이미지를 실제 업로드 */
   async function flushPendingProfileImage() {
     if (!pendingProfileFile) return;
-    const fd = new FormData();
-    fd.append('file', pendingProfileFile);
-    fd.append('category', 'artist');
-    const res = await fetch(`${API}/api/media`, { method: 'POST', body: fd });
-    if (!res.ok) throw new Error(await res.text());
-    const media = await res.json();
+    const media = await uploadMediaFile(API, pendingProfileFile, 'artist');
     form.image_media_id = media.id;
     selectedImageUrl = media.url;
     URL.revokeObjectURL(pendingProfileFile._previewUrl);
@@ -362,12 +357,17 @@
 
   // ── 저장 ───────────────────────────────────
   async function saveArtist() {
+    if (saving) return;
+    saving = true;
+    saveError = '';
+
     try {
       // 1. pending 이미지 먼저 업로드
       await flushPendingProfileImage();
       await flushPendingSubImages();
     } catch (e) {
-      alert('이미지 업로드 실패: ' + e.message);
+      saving = false;
+      saveError = '이미지 업로드 실패: ' + (e?.message || e);
       return;
     }
 
@@ -400,13 +400,13 @@
         : `${API}/api/artists`;
       const method = editing ? 'PUT' : 'POST';
 
-      const res = await fetch(url, { method, body: formData });
-      if (!res.ok) throw new Error(await res.text());
+      await fetchWithRetry(url, { method, body: formData });
 
       resetForm();
       await loadArtists();
     } catch (e) {
-      alert('저장 실패: ' + e.message);
+      saving = false;
+      saveError = '저장 실패: ' + (e?.message || e);
     }
   }
 
@@ -514,12 +514,16 @@
         <div class="modal-header-row">
           <h2>{editing ? '아티스트 편집' : '새 아티스트'}</h2>
           <div class="modal-header-actions">
-            <button class="btn-primary btn-save-top" onclick={saveArtist} disabled={!form.name}>
-              {editing ? '수정' : '등록'}
+            <button class="btn-primary btn-save-top" onclick={saveArtist} disabled={!form.name || saving}>
+              {saving ? '저장 중...' : (editing ? '수정' : '등록')}
             </button>
             <button class="modal-close" onclick={resetForm}>✕</button>
           </div>
         </div>
+
+        {#if saveError}
+          <p class="save-error">{saveError}</p>
+        {/if}
 
         <!-- 기본 정보 -->
         <div class="form-section">
@@ -778,8 +782,8 @@
         </div>
 
         <div class="form-actions">
-          <button class="btn-primary" onclick={saveArtist} disabled={!form.name}>
-            {editing ? '수정' : '생성'}
+          <button class="btn-primary" onclick={saveArtist} disabled={!form.name || saving}>
+            {saving ? '저장 중...' : (editing ? '수정' : '생성')}
           </button>
           <button class="btn-secondary" onclick={resetForm}>취소</button>
         </div>
@@ -1003,6 +1007,17 @@
     .modal-close { position: static; }
   }
   .btn-save-top { flex-shrink: 0; padding: 0.45rem 1rem; font-size: 0.85rem; }
+
+  .save-error {
+    background: #fef2f2;
+    color: #b91c1c;
+    border: 1px solid #fecaca;
+    border-radius: 6px;
+    padding: 0.6rem 0.9rem;
+    margin: 0 0 1rem;
+    font-size: 0.85rem;
+    white-space: pre-wrap;
+  }
 
   .modal-close {
     position: absolute;

--- a/src/routes/admin/auditions/+page.svelte
+++ b/src/routes/admin/auditions/+page.svelte
@@ -1,5 +1,6 @@
 <script>
   import { PIANOLIFE_BACKEND_URL } from '$env/static/public';
+  import { uploadMediaFile, fetchWithRetry } from '$lib/utils/uploadMedia.js';
 
   const API = PIANOLIFE_BACKEND_URL || 'http://localhost:8000';
 
@@ -33,6 +34,8 @@
   let bannerDragOver = $state(false);
   let pendingPosterFile = $state(null);
   let pendingBannerFile = $state(null);
+  let saving = $state(false);
+  let saveError = $state('');
 
   // ── 초기 로드 ──────────────────────────────
   $effect(() => { loadItems(); });
@@ -70,6 +73,8 @@
     pendingBannerFile = null;
     editing = null;
     showForm = false;
+    saving = false;
+    saveError = '';
   }
 
   function openCreate() {
@@ -116,12 +121,7 @@
   }
   async function flushPendingPoster() {
     if (!pendingPosterFile) return;
-    const fd = new FormData();
-    fd.append('file', pendingPosterFile);
-    fd.append('category', 'concert');
-    const res = await fetch(`${API}/api/media`, { method: 'POST', body: fd });
-    if (!res.ok) throw new Error(await res.text());
-    const media = await res.json();
+    const media = await uploadMediaFile(API, pendingPosterFile, 'concert');
     form.poster_media_id = media.id;
     selectedPosterUrl = media.url;
     URL.revokeObjectURL(pendingPosterFile._previewUrl);
@@ -157,12 +157,7 @@
   }
   async function flushPendingBanner() {
     if (!pendingBannerFile) return;
-    const fd = new FormData();
-    fd.append('file', pendingBannerFile);
-    fd.append('category', 'concert');
-    const res = await fetch(`${API}/api/media`, { method: 'POST', body: fd });
-    if (!res.ok) throw new Error(await res.text());
-    const media = await res.json();
+    const media = await uploadMediaFile(API, pendingBannerFile, 'concert');
     form.banner_image_media_id = media.id;
     selectedBannerUrl = media.url;
     URL.revokeObjectURL(pendingBannerFile._previewUrl);
@@ -179,11 +174,16 @@
 
   // ── 저장 ───────────────────────────────────
   async function saveItem() {
+    if (saving) return;
+    saving = true;
+    saveError = '';
+
     try {
       await flushPendingPoster();
       await flushPendingBanner();
     } catch (e) {
-      alert('이미지 업로드 실패: ' + e.message);
+      saving = false;
+      saveError = '이미지 업로드 실패: ' + (e?.message || e);
       return;
     }
 
@@ -201,12 +201,12 @@
     try {
       const url = editing ? `${API}/api/auditions/${editing.id}` : `${API}/api/auditions`;
       const method = editing ? 'PUT' : 'POST';
-      const res = await fetch(url, { method, body: formData });
-      if (!res.ok) throw new Error(await res.text());
+      await fetchWithRetry(url, { method, body: formData });
       resetForm();
       await loadItems();
     } catch (e) {
-      alert('저장 실패: ' + e.message);
+      saving = false;
+      saveError = '저장 실패: ' + (e?.message || e);
     }
   }
 
@@ -296,12 +296,16 @@
         <div class="modal-header-row">
           <h2>{editing ? '오디션 편집' : '새 오디션'}</h2>
           <div class="modal-header-actions">
-            <button class="btn-primary btn-save-top" onclick={saveItem} disabled={!form.title}>
-              {editing ? '수정' : '등록'}
+            <button class="btn-primary btn-save-top" onclick={saveItem} disabled={!form.title || saving}>
+              {saving ? '저장 중...' : (editing ? '수정' : '등록')}
             </button>
             <button class="modal-close" onclick={resetForm}>✕</button>
           </div>
         </div>
+
+        {#if saveError}
+          <p class="save-error">{saveError}</p>
+        {/if}
 
         <!-- 기본 정보 -->
         <div class="form-section">
@@ -404,8 +408,8 @@
         </div>
 
         <div class="form-actions">
-          <button class="btn-primary" onclick={saveItem} disabled={!form.title}>
-            {editing ? '수정' : '등록'}
+          <button class="btn-primary" onclick={saveItem} disabled={!form.title || saving}>
+            {saving ? '저장 중...' : (editing ? '수정' : '등록')}
           </button>
           <button class="btn-secondary" onclick={resetForm}>취소</button>
         </div>
@@ -548,6 +552,11 @@
     .modal-close { position: static; }
   }
   .btn-save-top { flex-shrink: 0; padding: 0.45rem 1rem; font-size: 0.85rem; }
+  .save-error {
+    background: #fef2f2; color: #b91c1c; border: 1px solid #fecaca;
+    border-radius: 6px; padding: 0.6rem 0.9rem; margin: 0 0 1rem;
+    font-size: 0.85rem; white-space: pre-wrap;
+  }
   .modal-close {
     position: absolute; top: 0.75rem; right: 0.75rem;
     background: none; border: none; color: #888; font-size: 1.4rem; cursor: pointer; z-index: 1;

--- a/src/routes/admin/concerts/+page.svelte
+++ b/src/routes/admin/concerts/+page.svelte
@@ -1,5 +1,6 @@
 <script>
   import { PIANOLIFE_BACKEND_URL } from '$env/static/public';
+  import { uploadMediaFile, fetchWithRetry } from '$lib/utils/uploadMedia.js';
 
   const API = PIANOLIFE_BACKEND_URL || 'http://localhost:8000';
 
@@ -35,6 +36,8 @@
   let showBannerMediaPicker = $state(false);
   let selectedPosterUrl = $state('');
   let selectedBannerUrl = $state('');
+  let saving = $state(false);
+  let saveError = $state('');
 
   // ── 드래그 앤 드롭 ────────────────────────────
   let imageUploading = $state(false);
@@ -108,6 +111,8 @@
     showPlaceResults = false;
     editing = null;
     showForm = false;
+    saving = false;
+    saveError = '';
   }
 
   function openCreate() {
@@ -337,12 +342,7 @@
     
     // 비동기 병렬 업로드 (Promise.all)
     const uploadPromises = pendingSubImageFiles.map(async (file) => {
-      const fd = new FormData();
-      fd.append('file', file);
-      fd.append('category', 'concert');
-      const res = await fetch(`${API}/api/media`, { method: 'POST', body: fd });
-      if (!res.ok) throw new Error(await res.text());
-      const media = await res.json();
+      const media = await uploadMediaFile(API, file, 'concert');
       return { file, media };
     });
 
@@ -387,12 +387,7 @@
   /** 저장 시 호출: pending 포스터를 실제 업로드 */
   async function flushPendingPoster() {
     if (!pendingPosterFile) return;
-    const fd = new FormData();
-    fd.append('file', pendingPosterFile);
-    fd.append('category', 'concert');
-    const res = await fetch(`${API}/api/media`, { method: 'POST', body: fd });
-    if (!res.ok) throw new Error(await res.text());
-    const media = await res.json();
+    const media = await uploadMediaFile(API, pendingPosterFile, 'concert');
     form.poster_media_id = media.id;
     selectedPosterUrl = media.thumb_url || media.url;
     URL.revokeObjectURL(pendingPosterFile._previewUrl);
@@ -436,12 +431,7 @@
   /** 저장 시 호출: pending 배너 이미지를 실제 업로드 */
   async function flushPendingBanner() {
     if (!pendingBannerFile) return;
-    const fd = new FormData();
-    fd.append('file', pendingBannerFile);
-    fd.append('category', 'concert');
-    const res = await fetch(`${API}/api/media`, { method: 'POST', body: fd });
-    if (!res.ok) throw new Error(await res.text());
-    const media = await res.json();
+    const media = await uploadMediaFile(API, pendingBannerFile, 'concert');
     form.banner_image_media_id = media.id;
     selectedBannerUrl = media.thumb_url || media.url;
     URL.revokeObjectURL(pendingBannerFile._previewUrl);
@@ -450,6 +440,10 @@
 
   // ── 저장 ───────────────────────────────────
   async function saveConcert() {
+    if (saving) return;
+    saving = true;
+    saveError = '';
+
     try {
       // 1. pending 이미지 먼저 병렬로 비동기 업로드
       await Promise.all([
@@ -458,7 +452,8 @@
         flushPendingSubImages()
       ]);
     } catch (e) {
-      alert('이미지 업로드 실패: ' + e.message);
+      saving = false;
+      saveError = '이미지 업로드 실패: ' + (e?.message || e);
       return;
     }
 
@@ -500,13 +495,13 @@
         : `${API}/api/concerts`;
       const method = editing ? 'PUT' : 'POST';
 
-      const res = await fetch(url, { method, body: formData });
-      if (!res.ok) throw new Error(await res.text());
+      await fetchWithRetry(url, { method, body: formData });
 
       resetForm();
       await loadConcerts();
     } catch (e) {
-      alert('저장 실패: ' + e.message);
+      saving = false;
+      saveError = '저장 실패: ' + (e?.message || e);
     }
   }
 
@@ -669,12 +664,16 @@
         <div class="modal-header-row">
           <h2>{editing ? '공연 편집' : '새 공연'}</h2>
           <div class="modal-header-actions">
-            <button class="btn-primary btn-save-top" onclick={saveConcert} disabled={!form.title}>
-              {editing ? '수정' : '등록'}
+            <button class="btn-primary btn-save-top" onclick={saveConcert} disabled={!form.title || saving}>
+              {saving ? '저장 중...' : (editing ? '수정' : '등록')}
             </button>
             <button class="modal-close" onclick={resetForm}>✕</button>
           </div>
         </div>
+
+        {#if saveError}
+          <p class="save-error">{saveError}</p>
+        {/if}
 
         <!-- 기본 정보 -->
         <div class="form-section">
@@ -990,8 +989,8 @@
         </div>
 
         <div class="form-actions">
-          <button class="btn-primary" onclick={saveConcert} disabled={!form.title}>
-            {editing ? '수정' : '생성'}
+          <button class="btn-primary" onclick={saveConcert} disabled={!form.title || saving}>
+            {saving ? '저장 중...' : (editing ? '수정' : '생성')}
           </button>
           <button class="btn-secondary" onclick={resetForm}>취소</button>
         </div>
@@ -1213,6 +1212,17 @@
     .modal-close { position: static; }
   }
   .btn-save-top { flex-shrink: 0; padding: 0.45rem 1rem; font-size: 0.85rem; }
+
+  .save-error {
+    background: #fef2f2;
+    color: #b91c1c;
+    border: 1px solid #fecaca;
+    border-radius: 6px;
+    padding: 0.6rem 0.9rem;
+    margin: 0 0 1rem;
+    font-size: 0.85rem;
+    white-space: pre-wrap;
+  }
 
   .modal-close {
     position: absolute;

--- a/src/routes/admin/concours/+page.svelte
+++ b/src/routes/admin/concours/+page.svelte
@@ -1,5 +1,6 @@
 <script>
   import { PIANOLIFE_BACKEND_URL } from '$env/static/public';
+  import { uploadMediaFile, fetchWithRetry } from '$lib/utils/uploadMedia.js';
 
   const API = PIANOLIFE_BACKEND_URL || 'http://localhost:8000';
 
@@ -38,6 +39,8 @@
   let selectedBannerUrl = $state('');
   let bannerDragOver = $state(false);
   let pendingBannerFile = $state(null);
+  let saving = $state(false);
+  let saveError = $state('');
 
   // ── 초기 로드 ──────────────────────────────
   $effect(() => { loadItems(); });
@@ -76,6 +79,8 @@
     pendingBannerFile = null;
     editing = null;
     showForm = false;
+    saving = false;
+    saveError = '';
   }
 
   function openCreate() {
@@ -128,12 +133,7 @@
   }
   async function flushPendingPoster() {
     if (!pendingPosterFile) return;
-    const fd = new FormData();
-    fd.append('file', pendingPosterFile);
-    fd.append('category', 'concert');
-    const res = await fetch(`${API}/api/media`, { method: 'POST', body: fd });
-    if (!res.ok) throw new Error(await res.text());
-    const media = await res.json();
+    const media = await uploadMediaFile(API, pendingPosterFile, 'concert');
     form.poster_media_id = media.id;
     selectedPosterUrl = media.url;
     URL.revokeObjectURL(pendingPosterFile._previewUrl);
@@ -169,12 +169,7 @@
   }
   async function flushPendingBanner() {
     if (!pendingBannerFile) return;
-    const fd = new FormData();
-    fd.append('file', pendingBannerFile);
-    fd.append('category', 'concert');
-    const res = await fetch(`${API}/api/media`, { method: 'POST', body: fd });
-    if (!res.ok) throw new Error(await res.text());
-    const media = await res.json();
+    const media = await uploadMediaFile(API, pendingBannerFile, 'concert');
     form.banner_image_media_id = media.id;
     selectedBannerUrl = media.url;
     URL.revokeObjectURL(pendingBannerFile._previewUrl);
@@ -215,11 +210,16 @@
 
   // ── 저장 ───────────────────────────────────
   async function saveItem() {
+    if (saving) return;
+    saving = true;
+    saveError = '';
+
     try {
       await flushPendingPoster();
       await flushPendingBanner();
     } catch (e) {
-      alert('이미지 업로드 실패: ' + e.message);
+      saving = false;
+      saveError = '이미지 업로드 실패: ' + (e?.message || e);
       return;
     }
 
@@ -253,12 +253,12 @@
     try {
       const url = editing ? `${API}/api/concours/${editing.id}` : `${API}/api/concours`;
       const method = editing ? 'PUT' : 'POST';
-      const res = await fetch(url, { method, body: formData });
-      if (!res.ok) throw new Error(await res.text());
+      await fetchWithRetry(url, { method, body: formData });
       resetForm();
       await loadItems();
     } catch (e) {
-      alert('저장 실패: ' + e.message);
+      saving = false;
+      saveError = '저장 실패: ' + (e?.message || e);
     }
   }
 
@@ -347,12 +347,16 @@
         <div class="modal-header-row">
           <h2>{editing ? '콩쿠르 편집' : '새 콩쿠르'}</h2>
           <div class="modal-header-actions">
-            <button class="btn-primary btn-save-top" onclick={saveItem} disabled={!form.title}>
-              {editing ? '수정' : '등록'}
+            <button class="btn-primary btn-save-top" onclick={saveItem} disabled={!form.title || saving}>
+              {saving ? '저장 중...' : (editing ? '수정' : '등록')}
             </button>
             <button class="modal-close" onclick={resetForm}>✕</button>
           </div>
         </div>
+
+        {#if saveError}
+          <p class="save-error">{saveError}</p>
+        {/if}
 
         <!-- 기본 정보 -->
         <div class="form-section">
@@ -558,8 +562,8 @@
         </div>
 
         <div class="form-actions">
-          <button class="btn-primary" onclick={saveItem} disabled={!form.title}>
-            {editing ? '수정' : '등록'}
+          <button class="btn-primary" onclick={saveItem} disabled={!form.title || saving}>
+            {saving ? '저장 중...' : (editing ? '수정' : '등록')}
           </button>
           <button class="btn-secondary" onclick={resetForm}>취소</button>
         </div>
@@ -704,6 +708,11 @@
     .modal-close { position: static; }
   }
   .btn-save-top { flex-shrink: 0; padding: 0.45rem 1rem; font-size: 0.85rem; }
+  .save-error {
+    background: #fef2f2; color: #b91c1c; border: 1px solid #fecaca;
+    border-radius: 6px; padding: 0.6rem 0.9rem; margin: 0 0 1rem;
+    font-size: 0.85rem; white-space: pre-wrap;
+  }
   .modal-close {
     position: absolute; top: 0.75rem; right: 0.75rem;
     background: none; border: none; color: #888; font-size: 1.4rem; cursor: pointer; z-index: 1;

--- a/src/routes/admin/gallery/+page.svelte
+++ b/src/routes/admin/gallery/+page.svelte
@@ -1,5 +1,6 @@
 <script>
   import { PIANOLIFE_BACKEND_URL } from '$env/static/public';
+  import { uploadMediaFile, fetchWithRetry } from '$lib/utils/uploadMedia.js';
 
   const API = PIANOLIFE_BACKEND_URL || 'http://localhost:8000';
 
@@ -127,15 +128,8 @@
 
     for (const file of dropFiles) {
       try {
-        // 1단계: media 업로드
-        const mForm = new FormData();
-        mForm.append('file', file);
-        mForm.append('category', uploadCategory);
-        if (addTitle) mForm.append('alt_text', addTitle);
-
-        const mRes = await fetch(`${API}/api/media`, { method: 'POST', body: mForm });
-        if (!mRes.ok) throw new Error('미디어 업로드 실패: ' + (await mRes.text()));
-        const media = await mRes.json();
+        // 1단계: media 업로드 (실패 시 자동 재시도)
+        const media = await uploadMediaFile(API, file, uploadCategory, { alt_text: addTitle || undefined });
 
         // 2단계: gallery_images에 추가
         const gForm = new FormData();
@@ -144,8 +138,7 @@
         if (addCategory) gForm.append('category', addCategory);
         gForm.append('sort_order', String(addSortOrder));
 
-        const gRes = await fetch(`${API}/api/gallery/`, { method: 'POST', body: gForm });
-        if (!gRes.ok) throw new Error('갤러리 추가 실패: ' + (await gRes.text()));
+        await fetchWithRetry(`${API}/api/gallery/`, { method: 'POST', body: gForm });
 
         uploadResults = [...uploadResults, { success: true, name: file.name }];
       } catch (e) {

--- a/src/routes/admin/notice/+page.svelte
+++ b/src/routes/admin/notice/+page.svelte
@@ -1,6 +1,7 @@
 <script>
   import { PIANOLIFE_BACKEND_URL } from '$env/static/public';
   import { marked } from 'marked';
+  import { uploadMediaFile, fetchWithRetry } from '$lib/utils/uploadMedia.js';
 
   const API = PIANOLIFE_BACKEND_URL || 'http://localhost:8000';
 
@@ -26,6 +27,8 @@
 
   let imageDragOver = $state(false);
   let pendingImageFile = $state(null);
+  let saving = $state(false);
+  let saveError = $state('');
 
   // ── 초기 로드 ──────────────────────────────
   $effect(() => { loadItems(); });
@@ -59,6 +62,8 @@
     editing = null;
     showForm = false;
     showPreview = false;
+    saving = false;
+    saveError = '';
   }
 
   function openCreate() {
@@ -99,12 +104,7 @@
   }
   async function flushPendingImage() {
     if (!pendingImageFile) return;
-    const fd = new FormData();
-    fd.append('file', pendingImageFile);
-    fd.append('category', 'notice');
-    const res = await fetch(`${API}/api/media`, { method: 'POST', body: fd });
-    if (!res.ok) throw new Error(await res.text());
-    const media = await res.json();
+    const media = await uploadMediaFile(API, pendingImageFile, 'notice');
     form.image_media_id = media.id;
     selectedImageUrl = media.url;
     URL.revokeObjectURL(pendingImageFile._previewUrl);
@@ -121,10 +121,15 @@
 
   // ── 저장 ───────────────────────────────────
   async function saveItem() {
+    if (saving) return;
+    saving = true;
+    saveError = '';
+
     try {
       await flushPendingImage();
     } catch (e) {
-      alert('이미지 업로드 실패: ' + e.message);
+      saving = false;
+      saveError = '이미지 업로드 실패: ' + (e?.message || e);
       return;
     }
 
@@ -137,12 +142,12 @@
     try {
       const url = editing ? `${API}/api/notices/${editing.id}` : `${API}/api/notices`;
       const method = editing ? 'PUT' : 'POST';
-      const res = await fetch(url, { method, body: formData });
-      if (!res.ok) throw new Error(await res.text());
+      await fetchWithRetry(url, { method, body: formData });
       resetForm();
       await loadItems();
     } catch (e) {
-      alert('저장 실패: ' + e.message);
+      saving = false;
+      saveError = '저장 실패: ' + (e?.message || e);
     }
   }
 
@@ -222,12 +227,16 @@
         <div class="modal-header-row">
           <h2>{editing ? '공지사항 편집' : '새 공지사항'}</h2>
           <div class="modal-header-actions">
-            <button class="btn-primary btn-save-top" onclick={saveItem} disabled={!form.title}>
-              {editing ? '수정' : '등록'}
+            <button class="btn-primary btn-save-top" onclick={saveItem} disabled={!form.title || saving}>
+              {saving ? '저장 중...' : (editing ? '수정' : '등록')}
             </button>
             <button class="modal-close" onclick={resetForm}>✕</button>
           </div>
         </div>
+
+        {#if saveError}
+          <p class="save-error">{saveError}</p>
+        {/if}
 
         <!-- 기본 정보 -->
         <div class="form-section">
@@ -291,8 +300,8 @@
         </div>
 
         <div class="form-actions">
-          <button class="btn-primary" onclick={saveItem} disabled={!form.title}>
-            {editing ? '수정' : '등록'}
+          <button class="btn-primary" onclick={saveItem} disabled={!form.title || saving}>
+            {saving ? '저장 중...' : (editing ? '수정' : '등록')}
           </button>
           <button class="btn-secondary" onclick={resetForm}>취소</button>
         </div>
@@ -412,6 +421,11 @@
     .modal-close { position: static; }
   }
   .btn-save-top { flex-shrink: 0; padding: 0.45rem 1rem; font-size: 0.85rem; }
+  .save-error {
+    background: #fef2f2; color: #b91c1c; border: 1px solid #fecaca;
+    border-radius: 6px; padding: 0.6rem 0.9rem; margin: 0 0 1rem;
+    font-size: 0.85rem; white-space: pre-wrap;
+  }
   .modal-close {
     position: absolute; top: 0.75rem; right: 0.75rem;
     background: none; border: none; color: #888; font-size: 1.4rem; cursor: pointer; z-index: 1;


### PR DESCRIPTION
This pull request introduces a unified, robust media upload utility with automatic retry logic, and refactors the admin "albums", "artists", and "auditions" pages to use it. It also improves the user experience during save operations by adding saving state management and clear error feedback in all forms.

**Media upload improvements:**
- Added `fetchWithRetry` and `uploadMediaFile` helpers to `uploadMedia.js` for resilient media uploads with automatic retries on network errors. (`src/lib/utils/uploadMedia.js` [src/lib/utils/uploadMedia.jsR1-R32](diffhunk://#diff-34576fce7c592d1e0f06870daebbcb5d5d2ef7b6908f62e702ac6bd6548b5ef5R1-R32))
- Refactored all media upload logic in the admin "albums", "artists", and "auditions" pages to use the new `uploadMediaFile` helper, removing duplicated code and ensuring consistent retry behavior. (`src/routes/admin/albums/+page.svelte` [[1]](diffhunk://#diff-5b53f8f72478e52f73921ff9f68f033a092ea28251c20e1e6ccbde29fc71181eL168-R173) `src/routes/admin/artists/+page.svelte` [[2]](diffhunk://#diff-9eb2df872ec7e23c61cd42ca1499a58929f9452768acd88517d597d9e69b8460L247-R252) [[3]](diffhunk://#diff-9eb2df872ec7e23c61cd42ca1499a58929f9452768acd88517d597d9e69b8460L351-R351) `src/routes/admin/auditions/+page.svelte` [[4]](diffhunk://#diff-4b14ba99b225fd4ca339d98fdd2491a4b642bfff772cc63cfe01038a33abf01eL119-R124) [[5]](diffhunk://#diff-4b14ba99b225fd4ca339d98fdd2491a4b642bfff772cc63cfe01038a33abf01eL160-R160)

**Save operation UX improvements:**
- Added `saving` and `saveError` state variables to all admin forms to prevent duplicate submissions and to display clear error messages on failure. The save buttons now show a loading state and are disabled while saving. (`src/routes/admin/albums/+page.svelte` [[1]](diffhunk://#diff-5b53f8f72478e52f73921ff9f68f033a092ea28251c20e1e6ccbde29fc71181eR33-R34) [[2]](diffhunk://#diff-5b53f8f72478e52f73921ff9f68f033a092ea28251c20e1e6ccbde29fc71181eR195-R203) [[3]](diffhunk://#diff-5b53f8f72478e52f73921ff9f68f033a092ea28251c20e1e6ccbde29fc71181eL333-R348) [[4]](diffhunk://#diff-5b53f8f72478e52f73921ff9f68f033a092ea28251c20e1e6ccbde29fc71181eL461-R471); `src/routes/admin/artists/+page.svelte` [[5]](diffhunk://#diff-9eb2df872ec7e23c61cd42ca1499a58929f9452768acd88517d597d9e69b8460R44-R45) [[6]](diffhunk://#diff-9eb2df872ec7e23c61cd42ca1499a58929f9452768acd88517d597d9e69b8460R360-R370) [[7]](diffhunk://#diff-9eb2df872ec7e23c61cd42ca1499a58929f9452768acd88517d597d9e69b8460L517-R527) [[8]](diffhunk://#diff-9eb2df872ec7e23c61cd42ca1499a58929f9452768acd88517d597d9e69b8460L781-R786); `src/routes/admin/auditions/+page.svelte` [[9]](diffhunk://#diff-4b14ba99b225fd4ca339d98fdd2491a4b642bfff772cc63cfe01038a33abf01eR37-R38) [[10]](diffhunk://#diff-4b14ba99b225fd4ca339d98fdd2491a4b642bfff772cc63cfe01038a33abf01eR177-R186) [[11]](diffhunk://#diff-4b14ba99b225fd4ca339d98fdd2491a4b642bfff772cc63cfe01038a33abf01eL299-R309) [[12]](diffhunk://#diff-4b14ba99b225fd4ca339d98fdd2491a4b642bfff772cc63cfe01038a33abf01eL407-R412)
- Error messages are now shown in a consistent, styled component above the form when a save or upload fails. (`src/routes/admin/albums/+page.svelte` [[1]](diffhunk://#diff-5b53f8f72478e52f73921ff9f68f033a092ea28251c20e1e6ccbde29fc71181eR639-R649); `src/routes/admin/artists/+page.svelte` [[2]](diffhunk://#diff-9eb2df872ec7e23c61cd42ca1499a58929f9452768acd88517d597d9e69b8460R1011-R1021); `src/routes/admin/auditions/+page.svelte` [[3]](diffhunk://#diff-4b14ba99b225fd4ca339d98fdd2491a4b642bfff772cc63cfe01038a33abf01eL299-R309)

**Minor UI and behavior tweaks:**
- Increased the media fetch limit and made the empty media list message more generic in the albums admin. (`src/routes/admin/albums/+page.svelte` [[1]](diffhunk://#diff-5b53f8f72478e52f73921ff9f68f033a092ea28251c20e1e6ccbde29fc71181eL66-R69) [[2]](diffhunk://#diff-5b53f8f72478e52f73921ff9f68f033a092ea28251c20e1e6ccbde29fc71181eL484-R493)
- Ensured form state resets properly after save attempts. (`src/routes/admin/albums/+page.svelte` [[1]](diffhunk://#diff-5b53f8f72478e52f73921ff9f68f033a092ea28251c20e1e6ccbde29fc71181eR87-R88); `src/routes/admin/artists/+page.svelte` [[2]](diffhunk://#diff-9eb2df872ec7e23c61cd42ca1499a58929f9452768acd88517d597d9e69b8460R140-R141); `src/routes/admin/auditions/+page.svelte` [[3]](diffhunk://#diff-4b14ba99b225fd4ca339d98fdd2491a4b642bfff772cc63cfe01038a33abf01eR76-R77)

These changes make media uploads more reliable, improve error handling, and provide a better overall admin experience.