### PR TITLE
notice에 기능 일부  추가

### DIFF
--- a/src/lib/utils/markdown.js
+++ b/src/lib/utils/markdown.js
@@ -1,0 +1,20 @@
+import { marked } from 'marked';
+
+/**
+ * marked는 연속된 빈 줄이 몇 개든 문단 구분 1번으로 뭉갠다(리스트 등 블록 구조는
+ * 유지하되, 첫 번째 빈 줄만 문단 경계로 쓰고 나머지는 무시). 2개를 초과하는
+ * 연속 개행은 앞뒤로 빈 줄을 낀 <br> HTML 블록으로 바꿔, 문단/리스트 파싱은
+ * 그대로 두면서 초과분만큼 실제 줄바꿈을 추가로 삽입한다.
+ */
+function preserveBlankLines(text) {
+  return text.replace(/\r\n/g, '\n').replace(/\n{2,}/g, (match) => {
+    const extra = match.length - 2;
+    if (extra <= 0) return match;
+    const breaks = Array(extra).fill('<br>').join('\n\n');
+    return '\n\n' + breaks + '\n\n';
+  });
+}
+
+export function renderMarkdown(content) {
+  return marked.parse(preserveBlankLines(content || ''), { breaks: true });
+}

--- a/src/routes/about/notice/[id]/+page.svelte
+++ b/src/routes/about/notice/[id]/+page.svelte
@@ -1,6 +1,6 @@
 <script>
     import { page } from '$app/stores';
-    import { marked } from 'marked';
+    import { renderMarkdown } from '$lib/utils/markdown.js';
     import { PIANOLIFE_BACKEND_URL } from '$env/static/public';
 
     const API = PIANOLIFE_BACKEND_URL || 'http://localhost:8000';
@@ -55,13 +55,18 @@
 
         {#if notice.image_mid_url || notice.image_url}
             <div class="notice-image-wrap">
-                <img class="notice-image" src={notice.image_mid_url || notice.image_url} alt={notice.title} />
+                <img
+                    class="notice-image"
+                    src={notice.image_mid_url || notice.image_url}
+                    alt={notice.title}
+                    style="max-width: {notice.image_width || 1280}px;"
+                />
             </div>
         {/if}
 
         <div class="notice-text-wrap">
             <div class="notice-content markdown-body">
-                {@html marked.parse(notice.content || '')}
+                {@html renderMarkdown(notice.content)}
             </div>
         </div>
     {/if}
@@ -140,6 +145,22 @@
 
     .notice-content {
         overflow-wrap: break-word;
+
+        :global(table) {
+            width: 100%;
+            margin: 1.5rem 0;
+            border-collapse: collapse;
+            text-align: center;
+        }
+        :global(th),
+        :global(td) {
+            border: 1px solid #ddd;
+            padding: 0.3rem 0.6rem;
+            text-align: center;
+        }
+        :global(th) {
+            font-weight: 700;
+        }
     }
 
     .status-msg {

--- a/src/routes/admin/notice/+page.svelte
+++ b/src/routes/admin/notice/+page.svelte
@@ -1,6 +1,6 @@
 <script>
   import { PIANOLIFE_BACKEND_URL } from '$env/static/public';
-  import { marked } from 'marked';
+  import { renderMarkdown } from '$lib/utils/markdown.js';
   import { uploadMediaFile, fetchWithRetry } from '$lib/utils/uploadMedia.js';
 
   const API = PIANOLIFE_BACKEND_URL || 'http://localhost:8000';
@@ -13,10 +13,13 @@
   let showPreview = $state(false);
 
   // ── 폼 데이터 ──────────────────────────────
+  const DEFAULT_IMAGE_WIDTH = 1280;
+
   let form = $state({
     title: '',
     content: '',
     image_media_id: null,
+    image_width: DEFAULT_IMAGE_WIDTH,
     is_active: true,
   });
 
@@ -56,7 +59,7 @@
 
   // ── 폼 초기화 ──────────────────────────────
   function resetForm() {
-    form = { title: '', content: '', image_media_id: null, is_active: true };
+    form = { title: '', content: '', image_media_id: null, image_width: DEFAULT_IMAGE_WIDTH, is_active: true };
     selectedImageUrl = '';
     pendingImageFile = null;
     editing = null;
@@ -77,6 +80,7 @@
       title: item.title || '',
       content: item.content || '',
       image_media_id: null,
+      image_width: item.image_width || DEFAULT_IMAGE_WIDTH,
       is_active: item.is_active ?? true,
     };
     selectedImageUrl = item.image_url || '';
@@ -137,6 +141,7 @@
     formData.append('title', form.title);
     formData.append('content', form.content || '');
     if (form.image_media_id) formData.append('image_media_id', String(form.image_media_id));
+    formData.append('image_width', String(form.image_width || DEFAULT_IMAGE_WIDTH));
     formData.append('is_active', String(form.is_active));
 
     try {
@@ -280,6 +285,30 @@
               <button type="button" class="btn-secondary" onclick={() => { selectedImageUrl = ''; form.image_media_id = null; pendingImageFile = null; }}>제거</button>
             {/if}
           </div>
+
+          {#if selectedImageUrl}
+            <div class="width-control">
+              <label for="image-width-slider">이미지 최대 너비: {form.image_width}px</label>
+              <div class="width-control-row">
+                <input
+                  id="image-width-slider"
+                  type="range"
+                  min="200"
+                  max="1280"
+                  step="10"
+                  bind:value={form.image_width}
+                />
+                <input
+                  type="number"
+                  min="200"
+                  max="1280"
+                  step="10"
+                  bind:value={form.image_width}
+                  class="width-number"
+                />
+              </div>
+            </div>
+          {/if}
         </div>
 
         <!-- 본문 (마크다운) -->
@@ -292,7 +321,7 @@
           </div>
           {#if showPreview}
             <div class="markdown-preview markdown-body">
-              {@html marked.parse(form.content || '_내용 없음_')}
+              {@html renderMarkdown(form.content || '_내용 없음_')}
             </div>
           {:else}
             <textarea bind:value={form.content} placeholder="마크다운 문법으로 작성하세요 (# 제목, **굵게**, - 목록 등)"></textarea>
@@ -460,6 +489,13 @@
     :global(img) { max-width: 100%; }
     :global(a) { color: #2563eb; }
     :global(ul), :global(ol) { padding-left: 1.5em; margin: 0 0 0.75em; }
+    :global(table) {
+      width: 100%; margin: 0 0 1em; border-collapse: collapse; text-align: center;
+    }
+    :global(th), :global(td) {
+      border: 1px solid #ddd; padding: 0.25rem 0.5rem; text-align: center;
+    }
+    :global(th) { font-weight: 700; }
   }
 
   .checkbox-label {
@@ -480,6 +516,19 @@
     .preview-img {
       max-width: 100%; max-height: 240px; border-radius: 8px;
       object-fit: contain; display: block; margin: 0 auto;
+    }
+  }
+
+  .width-control {
+    margin-top: 0.75rem;
+    label { display: block; margin-bottom: 0.4rem; font-size: 0.85rem; color: #444; }
+  }
+  .width-control-row {
+    display: flex; align-items: center; gap: 0.75rem;
+    input[type="range"] { flex: 1; }
+    .width-number {
+      width: 90px; padding: 0.4rem 0.5rem; border: 1px solid #d1d5db;
+      border-radius: 6px; color: #222; font-size: 0.85rem;
     }
   }
 


### PR DESCRIPTION
This pull request improves the handling and display of markdown content and notice images, particularly in the admin and notice detail pages. The main changes include a custom markdown renderer that preserves extra blank lines, enhanced table styling for markdown content, and the addition of an adjustable image width feature for notice images.

**Markdown Rendering Improvements**
- Added a new `renderMarkdown` utility in `markdown.js` that uses `marked` but preserves extra blank lines in the output for better readability. All markdown rendering in notice pages now uses this utility instead of directly using `marked`. [[1]](diffhunk://#diff-7e19c8dc92eb3cc59805ea681f9c014ce886a5dff3b8d3f2a91b31aa2d5f6a55R1-R20) [src/routes/about/notice/[id]/+page.svelteL3-R3](diffhunk://#diff-be3f0929464a3ec032a5a7261215f9d4974d6c68ba6ea2ebb70f1a239e9c9c6bL3-R3), [[2]](diffhunk://#diff-e0931b0cbc66e33d316f80d17313051514c17f7844cc67c84b1277025f055afdL3-R3) [src/routes/about/notice/[id]/+page.svelteL58-R69](diffhunk://#diff-be3f0929464a3ec032a5a7261215f9d4974d6c68ba6ea2ebb70f1a239e9c9c6bL58-R69), [[3]](diffhunk://#diff-e0931b0cbc66e33d316f80d17313051514c17f7844cc67c84b1277025f055afdL295-R324)

**Markdown Table Styling**
- Enhanced CSS for markdown tables in both the notice detail and admin pages to ensure tables are full-width, have clear borders, and are properly styled for readability. ([src/routes/about/notice/[id]/+page.svelteR148-R163](diffhunk://#diff-be3f0929464a3ec032a5a7261215f9d4974d6c68ba6ea2ebb70f1a239e9c9c6bR148-R163), [src/routes/admin/notice/+page.svelteR492-R498](diffhunk://#diff-e0931b0cbc66e33d316f80d17313051514c17f7844cc67c84b1277025f055afdR492-R498))

**Notice Image Width Control**
- Added a slider and number input in the admin notice form to allow setting the maximum display width (200–1280px) for notice images. This width is saved with the notice and applied when displaying the image. [[1]](diffhunk://#diff-e0931b0cbc66e33d316f80d17313051514c17f7844cc67c84b1277025f055afdR16-R22) [[2]](diffhunk://#diff-e0931b0cbc66e33d316f80d17313051514c17f7844cc67c84b1277025f055afdL59-R62) [[3]](diffhunk://#diff-e0931b0cbc66e33d316f80d17313051514c17f7844cc67c84b1277025f055afdR83) [[4]](diffhunk://#diff-e0931b0cbc66e33d316f80d17313051514c17f7844cc67c84b1277025f055afdR144) [[5]](diffhunk://#diff-e0931b0cbc66e33d316f80d17313051514c17f7844cc67c84b1277025f055afdR288-R311)
- Updated the notice detail page to use the stored image width when rendering the image. ([src/routes/about/notice/[id]/+page.svelteL58-R69](diffhunk://#diff-be3f0929464a3ec032a5a7261215f9d4974d6c68ba6ea2ebb70f1a239e9c9c6bL58-R69))

**Admin Form Enhancements**
- Ensured that form reset and edit actions correctly handle the new `image_width` field, and that the field is included in notice submissions. [[1]](diffhunk://#diff-e0931b0cbc66e33d316f80d17313051514c17f7844cc67c84b1277025f055afdL59-R62) [[2]](diffhunk://#diff-e0931b0cbc66e33d316f80d17313051514c17f7844cc67c84b1277025f055afdR83) [[3]](diffhunk://#diff-e0931b0cbc66e33d316f80d17313051514c17f7844cc67c84b1277025f055afdR144)

**UI/UX Improvements**
- Added styles for the new image width control in the admin form for a consistent and user-friendly interface.