### PR TITLE
콘서트 등록 시 대관 등록되도록 수정

### DIFF
--- a/src/routes/admin/concerts/+page.svelte
+++ b/src/routes/admin/concerts/+page.svelte
@@ -16,6 +16,7 @@
     title: '',
     date: '',
     time: '',
+    end_time: '',
     brief_description: '',
     reserve_link: '',
     cost: '',
@@ -98,7 +99,7 @@
   // ── 폼 초기화 ──────────────────────────────
   function resetForm() {
     form = {
-      title: '', date: '', time: '', brief_description: '', reserve_link: '', cost: '',
+      title: '', date: '', time: '', end_time: '', brief_description: '', reserve_link: '', cost: '',
       location: '', location_data: null, poster_media_id: null, banner_image_media_id: null, program: [], image_list: [], artist_ids: [], is_active: true,
     };
     selectedPosterUrl = '';
@@ -146,6 +147,7 @@
       title: concert.title || '',
       date: dateStr,
       time: timeStr,
+      end_time: concert.end_time || '',
       brief_description: concert.brief_description || '',
       reserve_link: concert.reserve_link || '',
       cost: concert.cost || '',
@@ -464,6 +466,7 @@
     const formData = new FormData();
     formData.append('title', form.title);
     if (combinedDate) formData.append('date', combinedDate);
+    formData.append('end_time', form.end_time || '');
     if (form.brief_description) formData.append('brief_description', form.brief_description);
     formData.append('reserve_link', form.reserve_link || '');
     formData.append('cost', form.cost || '');
@@ -688,10 +691,17 @@
               <input type="date" bind:value={form.date} />
             </label>
             <label>
-              시간
+              시작 시간
               <input type="time" bind:value={form.time} />
             </label>
           </div>
+          <label>
+            종료 시간
+            <input type="time" bind:value={form.end_time} />
+          </label>
+          <p style="font-size: 0.8rem; color: #999; margin: -0.25rem 0 0.75rem;">
+            날짜/시작/종료 시간이 모두 입력되면 대관 관리에 "공연" 일정으로 자동 등록됩니다.
+          </p>
           <label>
             장소
           </label>

--- a/src/routes/admin/rentals/+page.svelte
+++ b/src/routes/admin/rentals/+page.svelte
@@ -4,7 +4,8 @@
   const API = PIANOLIFE_BACKEND_URL || 'http://localhost:8000';
 
   const STATUS_LABEL = { pending: '승인 대기', approved: '승인 완료', rejected: '거절됨' };
-  const RENTAL_TYPES = ['레슨, 연습', '모임 대관', '공연 대관'];
+  // '공연'은 일반 대관 신청 폼에는 노출되지 않는 관리자 전용 카테고리 (콘서트 등록 시 자동 연동)
+  const RENTAL_TYPES = ['레슨, 연습', '모임 대관', '공연 대관', '공연'];
 
   // ── 상태 ──────────────────────────────────
   let items = $state([]);
@@ -73,6 +74,10 @@
   }
 
   async function saveItem() {
+    if (editing?.concert_id) {
+      alert('콘서트와 연동된 대관 일정입니다. 공연 관리 페이지에서 수정해주세요.');
+      return;
+    }
     if (form.start_time && form.end_time && form.start_time >= form.end_time) {
       alert('종료 시간은 시작 시간보다 늦어야 합니다.');
       return;
@@ -114,6 +119,10 @@
   }
 
   async function deleteItem(item) {
+    if (item.concert_id) {
+      alert('콘서트와 연동된 대관 일정입니다. 공연 관리 페이지에서 콘서트를 삭제해주세요.');
+      return;
+    }
     if (!confirm(`${item.date} ${item.start_time}~${item.end_time} 대관 예약을 삭제하시겠습니까?`)) return;
     try {
       await fetch(`${API}/api/rentals/admin/${item.id}`, { method: 'DELETE' });
@@ -183,17 +192,24 @@
               </td>
               <td>
                 <span class="badge source">{item.source === 'admin' ? '관리자 등록' : '온라인 신청'}</span>
+                {#if item.concert_id}
+                  <span class="badge concert-linked">콘서트 연동</span>
+                {/if}
               </td>
               <td>
                 <span class="badge status-{item.status}">{STATUS_LABEL[item.status] || item.status}</span>
               </td>
               <td class="actions">
-                {#if item.status === 'pending'}
-                  <button class="btn-sm btn-approve" onclick={() => setStatus(item, 'approved')}>승인</button>
-                  <button class="btn-sm btn-reject" onclick={() => setStatus(item, 'rejected')}>거절</button>
+                {#if item.concert_id}
+                  <a class="btn-sm btn-edit" href="/admin/concerts">공연 관리로 이동</a>
+                {:else}
+                  {#if item.status === 'pending'}
+                    <button class="btn-sm btn-approve" onclick={() => setStatus(item, 'approved')}>승인</button>
+                    <button class="btn-sm btn-reject" onclick={() => setStatus(item, 'rejected')}>거절</button>
+                  {/if}
+                  <button class="btn-sm btn-edit" onclick={() => openEdit(item)}>편집</button>
+                  <button class="btn-sm btn-delete" onclick={() => deleteItem(item)}>삭제</button>
                 {/if}
-                <button class="btn-sm btn-edit" onclick={() => openEdit(item)}>편집</button>
-                <button class="btn-sm btn-delete" onclick={() => deleteItem(item)}>삭제</button>
               </td>
             </tr>
           {/each}
@@ -354,6 +370,7 @@
     display: inline-block;
   }
   .badge.source { background: #eef2ff; color: #4338ca; }
+  .badge.concert-linked { background: #f3e8ff; color: #7e22ce; margin-left: 0.3rem; }
   .badge.status-pending { background: #fef3c7; color: #92400e; }
   .badge.status-approved { background: #dcfce7; color: #166534; }
   .badge.status-rejected { background: #fee2e2; color: #991b1b; }
@@ -372,7 +389,7 @@
     border: 1px solid #d1d5db; border-radius: 6px; cursor: pointer;
     &:hover { background: #e5e7eb; }
   }
-  .btn-sm { padding: 0.3rem 0.7rem; font-size: 0.85rem; border-radius: 4px; border: none; cursor: pointer; }
+  .btn-sm { padding: 0.3rem 0.7rem; font-size: 0.85rem; border-radius: 4px; border: none; cursor: pointer; display: inline-block; text-decoration: none; }
   .btn-edit { background: #2563eb; color: #fff; &:hover { background: #1d4ed8; } }
   .btn-delete { background: #dc3545; color: #fff; &:hover { background: #c82333; } }
   .btn-approve { background: #16a34a; color: #fff; &:hover { background: #15803d; } }


### PR DESCRIPTION
This pull request enhances the admin concert and rental management pages by improving the integration between concert schedules and rental events. The main focus is to ensure that concerts and their associated rentals are clearly linked, prevent accidental edits or deletions from the wrong interface, and provide a better user experience for administrators.

### Concert and Rental Integration

* Added an `end_time` field to the concert creation and editing form in `+page.svelte`, ensuring concerts have both start and end times for more precise scheduling. (`src/routes/admin/concerts/+page.svelte`) [[1]](diffhunk://#diff-81d54f082a23dfe6e0cb553bdf6d11b068ffe7303301a476caf1fca674553cdeR19) [[2]](diffhunk://#diff-81d54f082a23dfe6e0cb553bdf6d11b068ffe7303301a476caf1fca674553cdeL101-R102) [[3]](diffhunk://#diff-81d54f082a23dfe6e0cb553bdf6d11b068ffe7303301a476caf1fca674553cdeR150) [[4]](diffhunk://#diff-81d54f082a23dfe6e0cb553bdf6d11b068ffe7303301a476caf1fca674553cdeR469) [[5]](diffhunk://#diff-81d54f082a23dfe6e0cb553bdf6d11b068ffe7303301a476caf1fca674553cdeL691-R704)
* Updated the rental types to include a hidden "공연" (concert) category, which is only used for admin-linked concert events and not exposed in the general rental form. (`src/routes/admin/rentals/+page.svelte`)

### User Experience and Data Integrity

* Prevented editing or deleting of rental events that are linked to concerts from the rental management page, instead prompting users to manage these through the concert admin page. (`src/routes/admin/rentals/+page.svelte`) [[1]](diffhunk://#diff-63828d60ad693399324bc41df203320616b28047601c5a407cfe74a14c30afd8R77-R80) [[2]](diffhunk://#diff-63828d60ad693399324bc41df203320616b28047601c5a407cfe74a14c30afd8R122-R125)
* Added badges and navigation cues in the rental list to clearly indicate which rentals are linked to concerts, and provided a direct link to the concert management page for these items. (`src/routes/admin/rentals/+page.svelte`)

### UI Improvements

* Updated styles for badges and buttons to visually distinguish concert-linked rentals and improve consistency in the admin interface. (`src/routes/admin/rentals/+page.svelte`) [[1]](diffhunk://#diff-63828d60ad693399324bc41df203320616b28047601c5a407cfe74a14c30afd8R373) [[2]](diffhunk://#diff-63828d60ad693399324bc41df203320616b28047601c5a407cfe74a14c30afd8L375-R392)